### PR TITLE
[8.0][ADD] stock_product_orderpoint

### DIFF
--- a/stock_product_orderpoint/__init__.py
+++ b/stock_product_orderpoint/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in module root
+# directory
+##############################################################################
+from . import product

--- a/stock_product_orderpoint/__openerp__.py
+++ b/stock_product_orderpoint/__openerp__.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Stock Product Orderpoint',
+    'version': '8.0.0.0.0',
+    'category': 'Warehouse Management',
+    'sequence': 14,
+    'summary': '',
+    'description': """
+Stock Product Orderpoint
+========================
+Shows orderpoint information on products
+
+    """,
+    'author': 'ADHOC SA, Iván Todorovich <ivan.todorovich@gmail.com>',
+    'website': 'www.adhoc.com.ar',
+    'license': 'AGPL-3',
+    'images': [
+    ],
+    'depends': [
+        'sale_stock',
+    ],
+    'data': [
+        'product_view.xml',
+    ],
+    'demo': [
+    ],
+    'test': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/stock_product_orderpoint/product.py
+++ b/stock_product_orderpoint/product.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in module root
+# directory
+##############################################################################
+from openerp import models, fields
+
+
+class product_product(models.Model):
+    _inherit = 'product.product'
+
+    nbr_reordering_rules = fields.Integer(
+        'Reordering Rules', 
+        compute='_compute_nbr_reordering_rules')
+
+    reordering_min_qty = fields.Float(compute='_compute_nbr_reordering_rules')
+    reordering_max_qty = fields.Float(compute='_compute_nbr_reordering_rules')
+
+
+    def _compute_nbr_reordering_rules(self):
+        read_group_res = self.env['stock.warehouse.orderpoint'].read_group(
+            [('product_id', 'in', self.ids)],
+            ['product_id', 'product_min_qty', 'product_max_qty'],
+            ['product_id'])
+        res = {i: {} for i in self.ids}
+        for data in read_group_res:
+            res[data['product_id'][0]]['nbr_reordering_rules'] = int(data['product_id_count'])
+            res[data['product_id'][0]]['reordering_min_qty'] = data['product_min_qty']
+            res[data['product_id'][0]]['reordering_max_qty'] = data['product_max_qty']
+        for product in self:
+            product.nbr_reordering_rules = res[product.id].get('nbr_reordering_rules', 0)
+            product.reordering_min_qty = res[product.id].get('reordering_min_qty', 0)
+            product.reordering_max_qty = res[product.id].get('reordering_max_qty', 0)

--- a/stock_product_orderpoint/product_view.xml
+++ b/stock_product_orderpoint/product_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_product_tree" model="ir.ui.view">
+            <field name="name">product.product.tree</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="stock.view_stock_product_tree"/>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <field name="virtual_available" position="after">
+                    <field name="reordering_min_qty" />
+                    <field name="reordering_max_qty" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Copie el código tal cual estaba del respositorio oficial, y funcionó bien.
Fijate que te parece, lo probe aca y anduvo.

Lo que vi es que en la 9.0, si bien agrega estos campos calculados, no los agrega a la vista tree.
Yo sí hice esto acá.