### PR TITLE
[IMP] block manual lines only apply for moves where origin location "

### DIFF
--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -66,8 +66,10 @@ class StockMoveLine(models.Model):
     @api.constrains('qty_done')
     def _check_manual_lines(self):
         for rec in self.filtered(
-                lambda x: x.picking_id.picking_type_id.block_manual_lines
-                and x.product_qty < x.qty_done):
+                lambda x:
+                not x.location_id.should_bypass_reservation() and
+                x.picking_id.picking_type_id.block_manual_lines and
+                x.product_qty < x.qty_done):
             raise ValidationError(_(
                 "You can't transfer more quantity than reserved one!"))
 

--- a/stock_ux/models/stock_picking_type.py
+++ b/stock_ux/models/stock_picking_type.py
@@ -24,5 +24,6 @@ class StockPickingType(models.Model):
     block_manual_lines = fields.Boolean(
         string="Block force availability",
         help="Do not allow to confirm pickings with more quantity than the "
-        "reserved one",
+        "reserved one. This will only apply for moves where origin location "
+        "is not of type 'supplier', 'customer', 'inventory', 'production'",
     )


### PR DESCRIPTION
        "is not of type 'supplier', 'customer', 'inventory', 'production'