### PR TITLE
[IMP] stock_ux: Add invetory valuation by stock

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -41,6 +41,7 @@ Several improvements to stock:
 #. Add in products (template and variants) button to access to stock moves related.
 #. Change name to the menus Product Move and Product Move lines.
 #. Add to "To Do" filter in stock move the state "partially_available".
+#. Add a "value" field on the quants, usable in a current inventory valuation report. This brings the possibility to get the correct value by locations for standard (not for AVCO products or FIFO products).
 #. Add optional constraints configurable by Picking Type:
 
 * Block Picking Edit: Restrict to add lines or to send more quantity than the original quantity. This will only apply to users with group Restrict Edit Blocked Pickings.

--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock UX',
-    'version': '11.0.1.20.0',
+    'version': '11.0.1.21.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',
@@ -47,6 +47,7 @@
         'views/stock_backorder_confirmation_views.xml',
         'views/stock_return_picking_views.xml',
         'views/stock_picking_type_views.xml',
+        'views/stock_quant_views.xml',
         'wizards/stock_operation_wizard_views.xml',
         'wizards/res_config_settings_views.xml',
         'report/stock_ux_report.xml',

--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -10,3 +10,4 @@ from . import product_product
 from . import stock_warehouse_orderpoint
 from . import stock_move_line
 from . import stock_picking_type
+from . import stock_quant

--- a/stock_ux/models/stock_quant.py
+++ b/stock_ux/models/stock_quant.py
@@ -1,0 +1,41 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields, api
+
+
+class StockQuant(models.Model):
+    """ TODO Remove this in v13, all are included in that odoo version
+    """
+    _inherit = 'stock.quant'
+
+    value = fields.Float('Value', compute='_compute_value', readonly=True)
+
+    @api.depends('product_id.cost_method', 'quantity',
+                 'product_id.standard_price')
+    def _compute_value(self):
+        """ Compute the current accounting valuation of the quants by multiplying the quantity by
+        the standard price. This works well for standard and AVCO valuation, while not so much in
+        FIFO because it'll estimate the products at their last delivery price and not their real
+        value.
+        """
+        for quant in self:
+            quant.value = quant.quantity * quant.product_id.standard_price
+
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False,lazy=True):
+        """ This override is done in order for the grouped list view to display the total value of
+        the quants inside a location. This doesn't work out of the box because `value` is a computed
+        field.
+        """
+        if 'value' not in fields:
+            return super(StockQuant, self).read_group(domain, fields, groupby, offset=offset, limit=limit,
+                orderby=orderby, lazy=lazy)
+        res = super(StockQuant, self).read_group(domain, fields, groupby, offset=offset, limit=limit,
+            orderby=orderby, lazy=lazy)
+        for group in res:
+            if group.get('__domain'):
+                quants = self.search(group['__domain'])
+                group['value'] = sum(quant.value for quant in quants)
+        return res

--- a/stock_ux/views/stock_quant_views.xml
+++ b/stock_ux/views/stock_quant_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<odoo>
+    <!-- TODO remove this en v13 -->
+    <record id="view_stock_quant_tree_inherit" model="ir.ui.view">
+        <field name="name">stock.quant.tree.inherit</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='quantity']" position="after">
+                <field name="value" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add new report on stock reports. For the stock valuation (on quants)  to see the values by location, becase odoo remove this feature since v11 and reciently incoporate them on v13.