### PR TITLE
[11.0] [FIX] stock_picking_state: Changes in auto subestate allocation

### DIFF
--- a/stock_picking_state/models/stock_picking.py
+++ b/stock_picking_state/models/stock_picking.py
@@ -23,6 +23,7 @@ class StockPicking(models.Model):
             domain = [
                 ('state', '=', rec.state),
                 ('picking_type', '=', rec.picking_type_code)]
-            state_detail = self.env['stock.picking.state_detail'].search(
-                domain, limit=1, order="sequence asc")
-            rec.state_detail_id = state_detail
+            state_detail = self.env['stock.picking.state_detail'].search(domain, order="sequence asc")
+            if self.state_detail_id and self.state_detail_id in state_detail:
+                continue
+            rec.state_detail_id = state_detail and state_detail[0]


### PR DESCRIPTION
For the reson that "state" are compute field, now only change the substate if the you have not subestate or the substate are not able for the state that you really are now.