### PR TITLE
[12.0] [IMP] stock_ux: New way to restrict additional qty

### DIFF
--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -4,7 +4,7 @@
 ##############################################################################
 from odoo import models, api, fields, _
 from odoo.exceptions import ValidationError
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, float_compare
 
 
 class StockMoveLine(models.Model):
@@ -85,3 +85,6 @@ class StockMoveLine(models.Model):
     def _check_quantity(self):
         """If we work on move lines we want to ensure quantities are ok"""
         self.mapped('move_id')._check_quantity()
+        # We verify the case that does not have 'move_id' to restrict how does_check_quantity() in moves
+        if any(self.filtered(lambda x: not x.move_id and x.picking_id.picking_type_id.block_additional_quantity)):
+            raise ValidationError(_('You can not transfer more than the initial demand!'))


### PR DESCRIPTION
In this way we avoid not taking account the control of "initial quantities" when adding the move lines in the "Detail Operations"