### PR TITLE
[13.0] [PORT] from 12.0

### DIFF
--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -150,10 +150,14 @@ class StockMove(models.Model):
         return action
 
     @api.model
-    def create(self, vals):
-        if not vals.get('allocation_ids', False) and not vals.get('sale_line_id', False)\
-            and not vals.get('purchase_line_id', False) \
-                and 'picking_type_id' in vals and\
-                self.env['stock.picking.type'].browse(vals.get('picking_type_id')).block_additional_quantity:
-            raise ValidationError(_('You can not transfer more than the initial demand!'))
-        return super().create(vals)
+    def default_get(self, fields_list):
+        # We override the default_get to make stock moves created when the picking
+        # was confirmed , this way restrict to add more quantity that initial demand
+        defaults = super().default_get(fields_list)
+        if self.env.context.get('default_picking_id'):
+            picking_id = self.env['stock.picking'].browse(self.env.context['default_picking_id'])
+            if picking_id.state == 'confirmed':
+                defaults['state'] = 'confirmed'
+                defaults['product_uom_qty'] = 0.0
+                defaults['additional'] = True
+        return defaults


### PR DESCRIPTION
[12.0] [FIX] stock_ux: Set to confirm the move create by a picking in that state

This is another way to restrict the additional amount in stock moves, we change the way made in this commit https://github.com/ingadhoc/stock/commit/623b95c62992c60e68bd5028591c37571bcebb17, to avoid other errors. we only change the default state when creating moves to avoid creating them in "draft" since in this state the initial demand is editable. We only leave that for the planned transfers.