### PR TITLE
[11.0] [FIX] stock_request_ux: do the same in a loop.

### DIFF
--- a/stock_request_ux/models/stock_request.py
+++ b/stock_request_ux/models/stock_request.py
@@ -56,7 +56,8 @@ class StockRequest(models.Model):
         # ahora sobre escribimos y llamamos a nuestro cancel que propaga
         # deberiamos ver de hacer monkey patch mejor para que sea
         # heredable por otros modulos
-        self.sudo().mapped('move_ids')._cancel_quantity()
+        for move in self.sudo().mapped('move_ids'):
+            move._cancel_quantity()
         self.write({'state': 'cancel'})
         return True
 


### PR DESCRIPTION
We do this in this part because the method _cancel_quantity in the moves restrict the massive cancel for moves with different products. The problem is here _cancel_quantity

Ticket 26923