### PR TITLE
[11.0] [FIX] stock_batch_picking_ux: able to select all of pickings i…

### DIFF
--- a/stock_batch_picking_ux/__manifest__.py
+++ b/stock_batch_picking_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock Usability with Batch Picking and stock vouchers',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_batch_picking_ux/views/stock_batch_picking_views.xml
+++ b/stock_batch_picking_ux/views/stock_batch_picking_views.xml
@@ -71,7 +71,7 @@
 
             <field name="picking_ids" position="attributes">
                 <attribute name="context">{'show_print_button': 1}</attribute>
-                <attribute name="domain">[('partner_id', '=', partner_id), ('picking_type_id.code', '=', picking_code), ('state', 'in', ('confirmed', 'partially_available', 'assigned'))]</attribute>
+                <attribute name="domain">['|',('partner_id', '=', partner_id), ('picking_type_id.code', '=', picking_code), ('state', 'in', ('confirmed', 'partially_available', 'assigned'))]</attribute>
                 <!-- <attribute name="domain">[('partner_id', '=', partner_id), ('picking_type_id', '=', picking_type_id), ('state', 'in', ('confirmed', 'partially_available', 'assigned'))]</attribute> -->
             </field>
 


### PR DESCRIPTION
…f you don't select a partner.

We need to set an "or" to the field "partner_id" when this is false, to be able to select anyone's of the picking according the type of operation, for all of the partners.