### PR TITLE
[13.0] [FIX] stock_ux: Avoid restriction in packages assignment.

### DIFF
--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -84,6 +84,8 @@ class StockMoveLine(models.Model):
     @api.constrains('qty_done')
     def _check_quantity(self):
         """If we work on move lines we want to ensure quantities are ok"""
+        if self._context.get('put_in_pack', False):
+            return
         self.mapped('move_id')._check_quantity()
         # We verify the case that does not have 'move_id' to restrict how does_check_quantity() in moves
         if any(self.filtered(lambda x: not x.move_id and x.picking_id.picking_type_id.block_additional_quantity)):

--- a/stock_ux/models/stock_picking.py
+++ b/stock_ux/models/stock_picking.py
@@ -160,3 +160,7 @@ class StockPicking(models.Model):
         if self.filtered(
             lambda x: x.state == 'cancel' and not self.user_has_groups('stock_ux.allow_picking_cancellation')):
             raise ValidationError("Only User with 'Picking cancelation allow' rights can cancel pickings")
+
+    def _put_in_pack(self, move_line_ids):
+        # we send to skip a process of check qty when is sending through the copy method.
+        return super()._put_in_pack(move_line_ids.with_context(put_in_pack=True))


### PR DESCRIPTION
If you have the option "block_additional_quantity" in the pick operation and you want to put in package less quantity than the reserved quantity, the computation of the quantity_done in the move is taken duplicated quantity when the constrains is call. This problems is due the method _put_in_pack who is created a new line for the quantity done and then change the quantity for original move, but the order of this actions is cause that the alert of the more quantity is raised wrongly for the sum of the quantity of the 2 moves.
For instance you have 5 units reserved and you want to process for a package 4 units, this operation is blocked.
With this change we skip for the first calculation of qty when comes from a copy method.

**Ticket 38071**