### PR TITLE
[13.0] [IMP] stock_ux: Show pages in lot's form views.

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -40,6 +40,7 @@ Several improvements to stock:
 #. Add in products (template and variants) button to access to stock moves related.
 #. Change name to the menus Product Move and Product Move lines.
 #. Add to "To Do" filter in stock move the state "partially_available".
+#. Show always visible the notebook pages in lot form view when create and edit a lot from a stock move line.
 #. Add optional constraints configurable by Picking Type:
 
 * Block Picking Edit: Restrict to add lines or to send more quantity than the original quantity. This will only apply to users with group Restrict Edit Blocked Pickings.

--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock UX',
-    'version': '13.0.1.6.0',
+    'version': '13.0.1.7.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_ux/views/stock_move_line_views.xml
+++ b/stock_ux/views/stock_move_line_views.xml
@@ -93,8 +93,8 @@
             <field name="lot_id" position="attributes">
                 <attribute name="attrs">{'invisible': [('lots_visible', '=', False)]}</attribute>
                 <attribute name="domain">[('product_id', '=', product_id)]</attribute>
-                <attribute name="context">{'default_product_id': product_id, 'active_picking_id': picking_id, 'default_company_id':company_id}</attribute>
                 <attribute name="options">{'create':True, 'create_edit':True}</attribute>
+                <attribute name="context">{'default_product_id': product_id, 'active_picking_id': picking_id, 'default_company_id':company_id, 'display_complete':True}</attribute>
             </field>
             <field name="qty_done" position="before">
                 <field name="product_uom_qty" readonly="1"/>
@@ -119,6 +119,7 @@
                 <!-- for compatibility with web_m2x_options we force allowing create lots -->
                 <field name="lot_id" position="attributes">
                     <attribute name="options">{'create':True, 'create_edit':True}</attribute>
+                    <attribute name="context">{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id, 'display_complete':True}</attribute>
                 </field>
             </field>
         </record>
@@ -134,6 +135,12 @@
             <!-- for compatibility with web_m2x_options we force allowing create lots -->
             <field name="lot_id" position="attributes">
                 <attribute name="options">{'create':True, 'create_edit':True}</attribute>
+                <attribute name="context">{
+                            'active_picking_id': picking_id,
+                            'default_company_id': parent.company_id,
+                            'default_product_id': parent.product_id,
+                            'display_complete':True
+                        }</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
When create a "lot" since the stock move line, show the whole view to able to complete all information that you need when receive products.