### PR TITLE
[13.0][ADD]stock_ux: origin description on delivery slip

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -42,6 +42,7 @@ Several improvements to stock:
 #. Add to "To Do" filter in stock move the state "partially_available".
 #. Show always visible the notebook pages in lot form view when create and edit a lot from a stock move line.
 #. Add optional constraints configurable by Picking Type:
+#. Add optional print of origin description insted of product name in Delivery Slip report on transfers.
 
 * Block Picking Edit: Restrict to add lines or to send more quantity than the original quantity. This will only apply to users with group Restrict Edit Blocked Pickings.
 

--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock UX',
-    'version': '13.0.1.7.0',
+    'version': '13.0.1.8.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_ux/views/report_deliveryslip.xml
+++ b/stock_ux/views/report_deliveryslip.xml
@@ -7,6 +7,28 @@
                 <span t-field="o.observations"/>
             </p>
         </table>
+        <xpath expr="//table[@name='stock_move_table']/tbody/tr/td[1]" position="attributes">
+            <attribute name="t-if">o.env['ir.config_parameter'].sudo().get_param('stock_ux.delivery_slip_use_origin', 'False') == 'False'</attribute>
+        </xpath>
+        <xpath expr="//table[@name='stock_move_table']/tbody/tr/td[1]" position="after">
+            <td t-if="o.env['ir.config_parameter'].sudo().get_param('stock_ux.delivery_slip_use_origin') == 'True'">
+                <span t-field="move.name"/>
+                <p>
+                    <span t-field="move.description_picking"/>
+                </p>
+            </td>
+        </xpath>
+         <xpath expr="//table[@name='stock_move_line_table']/tbody/tr/td[1]" position="attributes">
+            <attribute name="t-if">o.env['ir.config_parameter'].sudo().get_param('stock_ux.delivery_slip_use_origin', 'False') == 'False'</attribute>
+        </xpath>
+        <xpath expr="//table[@name='stock_move_line_table']/tbody/tr/td[1]" position="after">
+            <td t-if="o.env['ir.config_parameter'].sudo().get_param('stock_ux.delivery_slip_use_origin') == 'True'">
+                <span t-field="move_line.move_id.name"/>
+                <p>
+                    <span t-field="move_line.move_id.description_picking"/>
+                </p>
+            </td>
+        </xpath>
     </template>
 
 </odoo>

--- a/stock_ux/wizards/res_config_settings.py
+++ b/stock_ux/wizards/res_config_settings.py
@@ -13,3 +13,8 @@ class ResConfigSettings(models.TransientModel):
         'Show Used Lots on Picking Operations',
         implied_group='stock_ux.group_operation_used_lots',
     )
+
+    delivery_slip_use_origin = fields.Boolean(
+        'En Comprobantes de Transferencia usar Descripción de Origen',
+        config_parameter='stock_ux.delivery_slip_use_origin'
+    )

--- a/stock_ux/wizards/res_config_settings_views.xml
+++ b/stock_ux/wizards/res_config_settings_views.xml
@@ -21,6 +21,20 @@
             <xpath expr="//field[@name='stock_mail_confirmation_template_id']/../../.." position="attributes">
                 <attribute name="invisible">True</attribute>
             </xpath>
+
+            <xpath expr="//div[@data-key='stock']/div[1]" position="inside">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="delivery_slip_use_origin"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="delivery_slip_use_origin"/>
+                            <div class="text-muted">
+                                Por defecto odoo imprime en los Comprobantes de Transferencia el nombre del producto, si marca esta opción en su lugar se utilizará la descripción de origen (la descripción de origen suele ser la descripción de venta o la descripción de la compra)
+                            </div>
+                        </div>
+                    </div>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Add optional print of origin description insted of product name in Delivery Slip report on transfers.