### PR TITLE
[IMP] delivery_ux: add field zip_codes

### DIFF
--- a/delivery_ux/__manifest__.py
+++ b/delivery_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Delivery UX',
-    'version': "13.0.1.0.0",
+    'version': "13.0.1.1.0",
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/delivery_ux/models/delivery_carrier.py
+++ b/delivery_ux/models/delivery_carrier.py
@@ -1,4 +1,6 @@
-from odoo import models, fields
+from odoo import models, fields, api, _
+from odoo.tools.safe_eval import safe_eval
+from odoo.exceptions import ValidationError
 
 
 class DeliveryCarrier(models.Model):
@@ -9,3 +11,22 @@ class DeliveryCarrier(models.Model):
         string='Carrier Address',
         help="Utilizado para el remito."
     )
+    zip_codes = fields.Char(
+        string="Zip codes",
+        help="A list of zip codes availables for this shipping method.\n"
+             "If the zip code of the client is not in this list it will not be able to select it."
+    )
+
+    @api.constrains('zip_codes')
+    def check_zip_codes_list(self):
+        try:
+            if self.zip_codes and not isinstance(safe_eval(self.zip_codes), list):
+                raise Exception
+        except Exception:
+            raise ValidationError(_("Invalid expression, the zip codes must be a list of numbers, something like: ['code1', 'code2']"))
+
+    def _match_address(self, partner):
+        res = super()._match_address(partner)
+        if res and self.zip_codes and partner.zip not in safe_eval(self.zip_codes):
+            return False
+        return res

--- a/delivery_ux/views/delivery_carrier_views.xml
+++ b/delivery_ux/views/delivery_carrier_views.xml
@@ -7,6 +7,11 @@
             <field name="integration_level" position="after">
                 <field name="partner_id"/>
             </field>
+            <group name="zip_to" position="after">
+                <group name="zip_codes">
+                    <field name="zip_codes"/>
+                </group>
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Odoo filters the shipping method checking if the zip of the partner is
between the zip "from" and "to" of the method. In some cases the
available zip codes are not consecutive, so we add a new field
"zip_codes" to set an explicit list of zip codes.