### PR TITLE
[FIX]stock_batch_picking_ux:remove split_lot button

### DIFF
--- a/stock_batch_picking_ux/__manifest__.py
+++ b/stock_batch_picking_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock Usability with Batch Picking and stock vouchers',
-    'version': '13.0.1.2.0',
+    'version': '13.0.1.3.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_batch_picking_ux/views/stock_batch_picking_views.xml
+++ b/stock_batch_picking_ux/views/stock_batch_picking_views.xml
@@ -96,7 +96,6 @@
             </field>
 
             <field name="qty_done" position="after">
-                <button name="split_lot" string="Lot Split" type="object" icon="fa-list" groups="stock.group_production_lot" attrs="{'invisible': ['|', ('lots_visible', '=', False), ('state', 'not in', ['confirmed', 'assigned', 'waiting', 'partially_available','done'])]}"/>
                 <button name="set_all_done" string="Set all Done" type="object" icon="fa-check" attrs="{'invisible': ['|', ('lots_visible', '=', True), ('state', 'not in', ['confirmed', 'assigned', 'waiting', 'partially_available'])]}"/>
             </field>
         </field>


### PR DESCRIPTION
Remove that button from detailded operations.Method actually not available
The method do the same as the operations line, so  is not necessary