### PR TITLE
[FIX] stock_ux: rename context keys

### DIFF
--- a/stock_request_ux/__manifest__.py
+++ b/stock_request_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock Request UX',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_request_ux/views/stock_move_views.xml
+++ b/stock_request_ux/views/stock_move_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="request_order_id" invisible="1"/>
-                <button name="action_view_linked_record" class="oe_stat_button" icon="fa-cubes" string="Request Orders" type="object" context="{'res_id': request_order_id, 'action_ref': 'stock_request.stock_request_order_action', 'form_view_ref': 'stock_request.stock_request_order_form'}" attrs="{'invisible': [('request_order_id', '=', False)]}">
+                <button name="action_view_linked_record" class="oe_stat_button" icon="fa-cubes" string="Request Orders" type="object" context="{'res_id': request_order_id, 'action': 'stock_request.stock_request_order_action', 'form_view': 'stock_request.stock_request_order_form'}" attrs="{'invisible': [('request_order_id', '=', False)]}">
                 </button>
             </xpath>
         </field>

--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -140,8 +140,8 @@ class StockMove(models.Model):
         of given picking.
         """
         self.ensure_one()
-        action_ref = self._context.get('action_ref')
-        form_view_ref = self._context.get('form_view_ref')
+        action_ref = self._context.get('action')
+        form_view_ref = self._context.get('form_view')
         action = self.env.ref(action_ref).read()[0]
         form_view = self.env.ref(form_view_ref)
         res_id = self._context.get('res_id')


### PR DESCRIPTION
This is to avoid context errors in other odoo actions.