### PR TITLE
[IMP] stock_orderpoint_manual_update: review toggle

### DIFF
--- a/stock_orderpoint_manual_update/README.rst
+++ b/stock_orderpoint_manual_update/README.rst
@@ -16,6 +16,7 @@ Stock Orderpoint Manual Update
 
 #. Improves performace when opening Replenishment menu.
 #. Allow to reorder the lines in Replenishment view according to the forecast qty, Add the filter "Negatives quantities".
+#. Adds a review toggle per line that allows the user to indicate when the replenishment order is ready to be confirmed.
 
 Installation
 ============

--- a/stock_orderpoint_manual_update/__manifest__.py
+++ b/stock_orderpoint_manual_update/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock Orderpoint Manual Update',
-    'version': "16.0.1.3.0",
+    'version': "16.0.1.4.0",
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_orderpoint_manual_update/i18n/es.po
+++ b/stock_orderpoint_manual_update/i18n/es.po
@@ -132,3 +132,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_orderpoint_manual_update.field_stock_warehouse_orderpoint_wizard__supplier_ids
 msgid "Vendor"
 msgstr "Proveedor"
+
+#. module: stock_orderpoint_manual_update
+#: model:ir.model.fields,field_description:stock_orderpoint_manual_update.field_stock_warehouse_orderpoint__reviewed
+msgid "Reviewed"
+msgstr "Revisado"

--- a/stock_orderpoint_manual_update/models/stock_orderpoint.py
+++ b/stock_orderpoint_manual_update/models/stock_orderpoint.py
@@ -18,6 +18,8 @@ class StockWarehouseOrderpoint(models.Model):
         string="Previsión",
     )
 
+    reviewed = fields.Boolean()
+
     def update_qty_forecast(self):
         for rec in self:
             rec.qty_forecast_stored = rec.qty_forecast
@@ -49,3 +51,16 @@ class StockWarehouseOrderpoint(models.Model):
         if location_ids:
             domain.append(('id', 'in', location_ids))
         return self.env['stock.location'].search(domain)
+
+    @api.onchange('qty_on_hand', 'qty_forecast_stored')
+    def _change_review_toggle_negative(self):
+            self.reviewed = False
+
+    @api.onchange('qty_to_order')
+    def _change_review_toggle_positive(self):
+            self.reviewed = True
+
+    def action_replenish(self):
+        res = super(StockWarehouseOrderpoint, self).action_replenish()
+        self._change_review_toggle_negative()
+        return res

--- a/stock_orderpoint_manual_update/views/stock_warehouse_orderpoint_views.xml
+++ b/stock_orderpoint_manual_update/views/stock_warehouse_orderpoint_views.xml
@@ -9,6 +9,9 @@
             <field name="qty_forecast" position="replace">
                 <field name="qty_forecast_stored"/>
             </field>
+            <field name="product_uom_name" position="replace">
+                <field name="reviewed" widget="boolean_toggle" />
+            </field>
         </field>
     </record>
 

--- a/stock_orderpoint_manual_update/wizard/stock_warehouse_orderpoint_wizard.py
+++ b/stock_orderpoint_manual_update/wizard/stock_warehouse_orderpoint_wizard.py
@@ -27,6 +27,7 @@ class StockWarehouseOrderpointWizard(models.TransientModel):
         orderpoints._compute_qty_to_order()
         orderpoints.update_qty_forecast()
         orderpoints._compute_rotation()
+        orderpoints._change_review_toggle_negative()
         action['domain'] = expression.AND([
             action.get('domain', '[]'),
             orderpoint_domain,


### PR DESCRIPTION
Adds a review toggle per line that allows the user to indicate when the replenishment order is ready to be confirmed.
1. When entering to the replensihment menu, by default all the toggle values ​​are disabled.
2. When you click on 'Order from one' or 'Order', the toggle is deactivated again for the records that the order was generated.
3. When modifying the fields 'On hand', 'Forecast' or 'To order' the field is deactivated again. 
4. You can Sort/Group/Filter using this field