### PR TITLE
[IMP] stock_orderpoint_manual_update: rm manual compute qty_to_order

### DIFF
--- a/stock_orderpoint_manual_update/wizard/stock_warehouse_orderpoint_wizard.py
+++ b/stock_orderpoint_manual_update/wizard/stock_warehouse_orderpoint_wizard.py
@@ -24,7 +24,6 @@ class StockWarehouseOrderpointWizard(models.TransientModel):
         action = self.with_context(ctx).env['stock.warehouse.orderpoint']._get_orderpoint_action()
         orderpoint_domain = self._get_orderpoint_domain()
         orderpoints = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(orderpoint_domain)
-        orderpoints._compute_qty_to_order()
         orderpoints.update_qty_forecast()
         orderpoints._compute_rotation()
         orderpoints._change_review_toggle_negative()


### PR DESCRIPTION
Since the Odoo commit #cb764a9 we don't need to call the compute method of qty_to_order manually.