### PR TITLE
[FIX]stock_ux: block_additional_qty for scrap

### DIFF
--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -12,3 +12,4 @@ from . import stock_move_line
 from . import stock_picking_type
 from . import res_config_settings
 from . import stock_rule
+from . import stock_scrap

--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -55,7 +55,9 @@ class StockMove(models.Model):
     def _check_quantity(self):
         precision = self.env['decimal.precision'].precision_get(
             'Product Unit of Measure')
-        if any(self.filtered(
+        if any(self.filtered(lambda x: x.scrapped)):
+            return
+        elif any(self.filtered(
             lambda x: x.picking_id.picking_type_id.
             block_additional_quantity and float_compare(
                 x.product_uom_qty, x.quantity,

--- a/stock_ux/models/stock_scrap.py
+++ b/stock_ux/models/stock_scrap.py
@@ -1,0 +1,21 @@
+from odoo import models, api, _
+from odoo.exceptions import UserError
+
+class StockScrap(models.Model):
+    _inherit = 'stock.scrap'
+
+    def action_validate(self):
+        total_scraped = sum(scrap.scrap_qty for scrap in self.env['stock.scrap'].search(
+            [('product_id', '=', self.product_id.id),
+            ('picking_id', '=', self.picking_id.id),
+            ('state', '=', 'done')]
+        ))
+        total_picking = sum(
+            move_id.product_uom_qty
+            for move_id in self.picking_id.move_ids
+            if move_id.product_id == self.product_id
+        )
+        if (self.scrap_qty + total_scraped) > total_picking:
+                raise UserError(_('No se puede desechar una cantidad mayor a la cantidad dentro de la transferencia del producto: %s.') % self.product_id.display_name)
+
+        return super().action_validate()


### PR DESCRIPTION
This change aims to bypass the check_quantity method when the stock move is a scrap move. Though, the scrap move checks that the scraped quantity is no bigger than the quantity of that product in the picking plus the quantity already scraped.