### PR TITLE
[FIX]stock_ux: reserve/unreserve a forecasted move

### DIFF
--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -14,3 +14,4 @@ from . import res_config_settings
 from . import stock_rule
 from . import stock_scrap
 from . import stock_location
+from . import stock_forecasted

--- a/stock_ux/models/stock_forecasted.py
+++ b/stock_ux/models/stock_forecasted.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+from odoo.exceptions import AccessError
+
+
+class StockForecasted(models.AbstractModel):
+    _inherit = "stock.forecasted_product_product"
+
+    @api.model
+    def action_unreserve_linked_picks(self, move_id):
+        if self.env.user.has_group("stock_ux.group_restrict_to_modify_reservations_from_planned"):
+            raise AccessError("You are not allowed to unreserve stock.")
+        return super().action_unreserve_linked_picks(move_id)
+
+    @api.model
+    def action_reserve_linked_picks(self, move_id):
+        if self.env.user.has_group("stock_ux.group_restrict_to_modify_reservations_from_planned"):
+            raise AccessError("You are not allowed to reserve stock.")
+        return super().action_reserve_linked_picks(move_id)


### PR DESCRIPTION
not allow to reserve/unreserve a forecasted stock move for users without the permision