### PR TITLE
[FIX] stock_ux: Fix copy paste ugly code

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Stock UX',
-    'version': "17.0.1.10.0",
+    'version': "17.0.1.11.0",
     'category': 'Warehouse Management',
     'sequence': 14,
     'summary': '',

--- a/stock_ux/wizards/stock_label_type.py
+++ b/stock_ux/wizards/stock_label_type.py
@@ -1,13 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models,api, Command
+from odoo import _, fields, models, api, Command
+from odoo.exceptions import ValidationError
 
 
 class ProductLabelLayout(models.TransientModel):
     _inherit = 'product.label.layout'
+
     picking_id = fields.Many2one('stock.picking',string='picking')
-    line_ids = fields.One2many('stock.picking.zpl.lines','picking_zpl_id', string='Moves')
-    
+    line_ids = fields.One2many("product.label.layout.lines", "label_layout_id", string="Moves")
+
     @api.model
     def default_get(self, default_fields):
         rec = super().default_get(default_fields)
@@ -25,22 +27,19 @@ class ProductLabelLayout(models.TransientModel):
         report_action['close_on_report_download']=True
         return report_action
 
-class StockPickingZplLines(models.TransientModel):
-    _name = 'stock.picking.zpl.lines'
-    _description = "Print Stock Voucher lines"
+class ProductLabelLayoutLines(models.TransientModel):
 
-    picking_zpl_id = fields.Many2one('product.label.layout')
+    _name = "product.label.layout.lines"
+    _description = "Label layout lines"
 
-    move_id = fields.Many2one('stock.move')
-
+    label_layout_id = fields.Many2one("product.label.layout")
+    move_id = fields.Many2one("stock.move")
     move_quantity = fields.Float()
+    move_uom_id = fields.Many2one("uom.uom")
+    name = fields.Char(related="move_id.name")
 
-    move_uom_id = fields.Many2one('uom.uom')
-
-    name = fields.Char(related='move_id.name')
-
-    @api.constrains('move_quantity')
+    @api.constrains("move_quantity")
     def _check_move_quantity(self):
         for line in self:
             if line.move_quantity > line.move_id.quantity:
-                raise exceptions.ValidationError("La cantidad a imprimir no puede ser mayor que la cantidad original.")
+                raise ValidationError(_("La cantidad a imprimir no puede ser mayor que la cantidad original."))

--- a/stock_voucher/wizards/stock_picking_wizard.py
+++ b/stock_voucher/wizards/stock_picking_wizard.py
@@ -1,13 +1,14 @@
-from odoo import fields, api, models, Command, exceptions
-from odoo.exceptions import UserError
+from odoo import fields, api, models, Command
+from odoo.exceptions import UserError, ValidationError
 
 
 class StockPickingZpl(models.TransientModel):
+
     _inherit = 'product.label.layout'
 
     picking_id = fields.Many2one('stock.picking',string='picking')
     line_ids = fields.One2many('stock.picking.zpl.lines','picking_zpl_id', string='Moves')
-    
+
     @api.model
     def default_get(self, default_fields):
         rec = super().default_get(default_fields)
@@ -19,41 +20,38 @@ class StockPickingZpl(models.TransientModel):
             move_ids = self.env[active_model].browse(active_ids).mapped('move_ids').filtered(lambda x: x.quantity > 0 )
             rec['line_ids'] = [Command.create({'move_id': x.id, 'move_quantity':x.quantity,'move_uom_id': x.product_uom}) for x in move_ids]
         return rec
-    
+
     def action_print(self):
         self.ensure_one()
         report_id = self.env.ref("stock_voucher.action_custom_barcode_transfer_template_view_zpl")
         report_action = report_id.report_action(self.ids)
         report_action['close_on_report_download']=True
         return report_action
-    
+
     def action_print_pdf(self):
         self.ensure_one()
         picking_id = self.picking_id.id if self.picking_id else False
         if not picking_id:
-            raise UserError("No se encontró un picking asociado al registro.")  
+            raise UserError("No se encontró un picking asociado al registro.")
         report_id = self.env.ref("stock_voucher.action_custom_label_transfer_template_view_pdf")
         report_action = report_id.report_action([picking_id])
-        report_action['close_on_report_download'] = True   
+        report_action['close_on_report_download'] = True
         return report_action
 
 
 class StockPickingZplLines(models.TransientModel):
+
     _name = 'stock.picking.zpl.lines'
     _description = "Print Stock Voucher lines"
 
     picking_zpl_id = fields.Many2one('product.label.layout')
-
     move_id = fields.Many2one('stock.move')
-
     move_quantity = fields.Float()
-
     move_uom_id = fields.Many2one('uom.uom')
-
     name = fields.Char(related='move_id.name')
 
     @api.constrains('move_quantity')
     def _check_move_quantity(self):
         for line in self:
             if line.move_quantity > line.move_id.quantity:
-                raise exceptions.ValidationError("La cantidad a imprimir no puede ser mayor que la cantidad original.")
+                raise ValidationError("La cantidad a imprimir no puede ser mayor que la cantidad original.")


### PR DESCRIPTION
The class stock.picking.zpl.lines should not be reused without an inherit and pointing to the same field two models