### PR TITLE
[ADD] stock_report_substitute: initial bridge module between stock and report_substitute to handle _attach_sign

### DIFF
--- a/stock_report_substitute/README.rst
+++ b/stock_report_substitute/README.rst
@@ -1,0 +1,81 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========================
+Stock Report Substitute
+===========================
+
+
+This module serves as a bridge between the stock and the OCA's ``report_substitute`` module.
+It solves the error that occurs when digitally signing delivery slips when there's a substitution report configured.
+
+This module modifies the ``_attach_sign`` method in the ``stock.picking`` model to:
+
+#. Check if there's a substitute report for the delivery report
+#. If there is a substitute: render that report directly
+#. If there isn't: use Odoo's standard flow
+
+This ensures that digital signing works correctly for both native and substitute reports.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install this module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. No additional configuration is required. The module works automatically once installed.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Configure report substitution rules in the ``report_substitute`` module
+#. When digitally signing delivery slips, the module will automatically handle report substitution
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/stock/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/stock_report_substitute/__init__.py
+++ b/stock_report_substitute/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_report_substitute/__manifest__.py
+++ b/stock_report_substitute/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Stock Report Substitute",
+    "version": "18.0.1.0.0",
+    "category": "Inventory",
+    "summary": "Bridge module between stock and report_substitute for digital signing",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "stock",
+        "report_substitute",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/stock_report_substitute/models/__init__.py
+++ b/stock_report_substitute/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_report_substitute/models/stock_picking.py
+++ b/stock_report_substitute/models/stock_picking.py
@@ -1,0 +1,48 @@
+# Copyright 2025 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _attach_sign(self):
+        """
+        Attach signed delivery slip to the picking.
+
+        This override ensures that if a substitution report is defined
+        for the delivery slip, it is used instead of the native report.
+        Otherwise, it falls back to the standard Odoo behavior.
+        """
+        self.ensure_one()
+
+        # Get the native delivery report
+        delivery_report = self.env.ref("stock.action_report_delivery")
+
+        # Check if there's a substitution report for this picking
+        try:
+            substitution_report = delivery_report.get_substitution_report(self.ids)
+        except Exception:
+            # If substitution check fails, fall back to native behavior
+            substitution_report = False
+
+        if substitution_report:
+            # Render the substitute report directly
+            report_data = substitution_report._render(substitution_report.report_name, self.ids)
+            # report_data is a tuple (pdf_content, format)
+            filename = "%s_signed_delivery_slip" % self.name
+
+            if self.partner_id:
+                message = _("Order signed by %s", self.partner_id.name)
+            else:
+                message = _("Order signed")
+
+            # Attach the report to the picking
+            file_extension = report_data[1] if len(report_data) > 1 and report_data[1] else "pdf"
+            self.message_post(
+                attachments=[("%s.%s" % (filename, file_extension), report_data[0])],
+                body=message,
+            )
+            return True
+        return super()._attach_sign()


### PR DESCRIPTION
This new module acts as a bridge between stock and report_substitute.
It overrides the method _attach_sign in stock.picking to properly handle cases where a substitution report exists for the delivery slip, rendering and attaching the substitute report instead of the native one.

The module extends _attach_sign to render and attach substitution reports when available.