### PR TITLE
[FIX] stock_ux: Do not replace TD

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/views/report_deliveryslip.xml
+++ b/stock_ux/views/report_deliveryslip.xml
@@ -32,7 +32,9 @@
     </template>
 
     <template id="stock_report_delivery_aggregated_move_lines" inherit_id="stock.stock_report_delivery_aggregated_move_lines">
-        <xpath expr="//td[@name='move_line_aggregated_qty_ordered']" position="replace"/>
+        <xpath expr="//td[@name='move_line_aggregated_qty_ordered']" position="attributes">
+            <attribute name="style">display: none;</attribute>
+        </xpath>
     </template>
 
     <template id="custom_stock_report_delivery_aggregated_move_lines" inherit_id="stock.stock_report_delivery_aggregated_move_lines">


### PR DESCRIPTION
Hide the <td> instead of replacing it, since it is required by `stock_secondary_unit`