### PR TITLE
[IMP] stock_ux: Add restriction to edit operation type in pickings

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -38,6 +38,7 @@ Stock UX
 #. Add an optional setting to print remaining quantities not yet delivered on Delivery Slips: "Show remaining quantities not yet delivered on Delivery Slips."print remaining quantities not yet delivered
 #. Adds a review toggle per line that allows the user to indicate when the replenishment order is ready to be confirmed.
 #. Add a "All transfers" view form in Menu: Operations
+#. Add a restriction to edit operation type for users with the "Restrict editing Operation Type in Pickings" check.
 
 Installation
 ============

--- a/stock_ux/models/stock_picking.py
+++ b/stock_ux/models/stock_picking.py
@@ -133,3 +133,30 @@ class StockPicking(models.Model):
                     "It may cause an error when trying to render the 'Shipping Label' template",
                 }
             }
+
+    def write(self, vals):
+        """
+        Overrides the default write method to restrict changing the 'picking_type_id' field
+        for users belonging to the 'group_restrict_edit_picking_type' group. If a user in this
+        group attempts to modify the 'picking_type_id' of a picking that already has a value set,
+        a UserError is raised to prevent the operation. Otherwise, proceeds with the standard
+        write operation.
+
+        :param vals: Dictionary of field values to update.
+        :raises UserError: If a restricted user tries to change the 'picking_type_id' after it has been set.
+        :return: Result of the superclass write method.
+        """
+
+        if "picking_type_id" in vals:
+            user = self.env.user
+            if user.has_group("stock_ux.group_restrict_edit_picking_type"):
+                for picking in self:
+                    if picking.picking_type_id:
+                        raise UserError(
+                            _(
+                                "You cannot change the Operation Type once it has been set. "
+                                "This action is restricted for your user. "
+                                "Please contact your Inventory Manager if you need to perform this operation."
+                            )
+                        )
+        return super().write(vals)

--- a/stock_ux/security/stock_ux_security.xml
+++ b/stock_ux/security/stock_ux_security.xml
@@ -14,4 +14,10 @@
         <field name="name">Restrict to modify reservations from planned</field>
     </record>
 
+    <!-- restriction to edit operation type for users with this check -->
+    <record model="res.groups" id="group_restrict_edit_picking_type">
+        <field name="name">Restrict editing Operation Type in Pickings</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
- Add new security group 'Restrict editing Operation Type in Pickings'
- Implement write method override in stock.picking to prevent users with restriction group from editing picking_type_id after it's set
- Only affects users belonging to the restriction group
- Other users maintain normal editing capabilities
- Update README with new functionality description

This addresses the security concern in v18 where picking_type_id was editable by basic inventory users, which could lead to dangerous changes in delivery planning and warehouse management.