### PR TITLE
[FIX] stock_voucher: prevent division by zero in declared value calculation

### DIFF
--- a/stock_voucher/models/stock_picking.py
+++ b/stock_voucher/models/stock_picking.py
@@ -214,10 +214,10 @@ class StockPicking(models.Model):
                                 move.product_uom_qty / bom_quantity)
                             done_avg.append(
                                 move.quantity / bom_quantity)
-                        picking_value += so_bom_line.price_reduce_taxexcl * (
-                            sum(picking_avg) / len(picking_avg))
-                        done_value += so_bom_line.price_reduce_taxexcl * (
-                            sum(done_avg) / len(done_avg))
+                        if picking_avg:
+                            picking_value += so_bom_line.price_reduce_taxexcl * (sum(picking_avg) / len(picking_avg))
+                        if done_avg:
+                            done_value += so_bom_line.price_reduce_taxexcl * (sum(done_avg) / len(done_avg))
 
             declared_value = picking_value if inmediate_transfer\
                 else done_value


### PR DESCRIPTION
When product_id differs between sale order line and stock move, the move
is treated as a potential BOM component. If no valid BOM is found or no
components match, the picking_avg and done_avg lists remain empty,
causing a ZeroDivisionError when calculating averages.

Add validation to ensure lists are not empty before division.
