### PR TITLE
[FIX] stock_ux: backport Odoo v19 for 'To Reorder' filter performance

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/migrations/18.0.1.5.0/post-migration.py
+++ b/stock_ux/migrations/18.0.1.5.0/post-migration.py
@@ -1,0 +1,59 @@
+# Copyright 2025 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Populate qty_to_order_computed for existing orderpoints.
+
+    Backport from v19: qty_to_order_computed is now a stored field.
+    This migration computes the initial values for all existing orderpoints.
+    Processing is done in batches to avoid memory issues on large databases.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    _logger.info("Starting migration: populating qty_to_order_computed for orderpoints")
+
+    # Get all orderpoints (including archived ones)
+    orderpoints = env["stock.warehouse.orderpoint"].with_context(active_test=False).search([])
+    total = len(orderpoints)
+
+    if not total:
+        _logger.info("No orderpoints found, skipping migration")
+        return
+
+    _logger.info("Found %d orderpoints to process", total)
+
+    # Process in batches to avoid memory issues
+    batch_size = 500
+    processed = 0
+
+    for i in range(0, total, batch_size):
+        batch = orderpoints[i : i + batch_size]
+        try:
+            batch._compute_qty_to_order_computed()
+            processed += len(batch)
+            _logger.info("Processed %d/%d orderpoints", processed, total)
+            # pylint: disable=invalid-commit
+            # Commit is required in migration scripts to avoid memory issues on large databases
+            cr.commit()
+        except Exception as e:
+            _logger.error("Error processing batch %d-%d: %s", i, i + batch_size, e)
+            cr.rollback()
+            # Try to process individually on error
+            for orderpoint in batch:
+                try:
+                    orderpoint._compute_qty_to_order_computed()
+                    processed += 1
+                    # pylint: disable=invalid-commit
+                    cr.commit()
+                except Exception as e2:
+                    _logger.error("Error processing orderpoint %d: %s", orderpoint.id, e2)
+                    cr.rollback()
+
+    _logger.info("Migration completed: %d/%d orderpoints processed successfully", processed, total)

--- a/stock_ux/migrations/18.0.1.5.0/pre-migration.py
+++ b/stock_ux/migrations/18.0.1.5.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2025 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """Create index on warehouse_id for stock_warehouse_orderpoint table.
+
+    Backport from v19: This index improves query performance when filtering
+    orderpoints by warehouse, which is a common operation.
+    """
+    # Check if index already exists
+    cr.execute("""
+        ALTER TABLE stock_warehouse_orderpoint
+        ADD COLUMN qty_to_order_computed numeric
+    """)

--- a/stock_ux/models/stock_rule.py
+++ b/stock_ux/models/stock_rule.py
@@ -15,3 +15,27 @@ class StockRule(models.Model):
         """Make True by default if picking code is outgoing"""
         for rec in self:
             rec.propagate_carrier = rec.picking_type_id.code == "outgoing"
+
+    def _run_pull(self, procurements):
+        """Backport from v19: recompute orderpoints after move creation for performance.
+
+        Since qty_to_order_computed is now stored, we need to trigger its recomputation
+        when moves are created to keep the stored values up to date.
+        """
+        result = super()._run_pull(procurements)
+
+        # Extract orderpoints from procurements and recompute their qty_to_order_computed
+        # procurement is a namedtuple:
+        # (product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
+        orderpoints = self.env["stock.warehouse.orderpoint"]
+        for procurement, rule in procurements:
+            # Access values dict from the namedtuple (index 7 or .values attribute)
+            values = procurement.values
+            if values.get("orderpoint_id"):
+                orderpoints |= values["orderpoint_id"]
+
+        # Recompute only the affected orderpoints for performance
+        if orderpoints:
+            orderpoints.sudo()._compute_qty_to_order_computed()
+
+        return result

--- a/stock_ux/models/stock_warehouse_orderpoint.py
+++ b/stock_ux/models/stock_warehouse_orderpoint.py
@@ -16,15 +16,24 @@ class StockWarehouseOrderpoint(models.Model):
     _name = "stock.warehouse.orderpoint"
     _inherit = ["stock.warehouse.orderpoint", "mail.thread"]
 
+    # Backport from v19: add index for better performance
+    warehouse_id = fields.Many2one(index=True)
+
     active_product = fields.Boolean(string="Product Active", related="product_id.active")
+
+    # Backport from v19: store qty_to_order_computed for better performance
+    qty_to_order_computed = fields.Float(
+        store=True,
+    )
+
     rotation_stdev = fields.Float(
         compute="_compute_rotation",
-        help="Desvío estandar de las cantidades entregas a clientes en los " "últimos 120 días.",
+        help="Desvío estandar de las cantidades entregas a clientes en los últimos 120 días.",
         digits="Product Unit of Measure",
     )
     warehouse_rotation_stdev = fields.Float(
         compute="_compute_rotation",
-        help="Desvío estandar de las cantidades entregas desde este almacen" " a clientes en los últimos 120 días.",
+        help="Desvío estandar de las cantidades entregas desde este almacen a clientes en los últimos 120 días.",
         digits="Product Unit of Measure",
     )
     rotation = fields.Float(
@@ -47,6 +56,51 @@ class StockWarehouseOrderpoint(models.Model):
     location_id = fields.Many2one(tracking=True)
     product_id = fields.Many2one(tracking=True)
     reviewed = fields.Boolean()
+
+    # Backport from v19: updated depends for qty_to_order_computed
+    # Note: qty_forecast depends on stock_move_ids which changes frequently.
+    # We intentionally don't include it to avoid constant recomputation.
+    # Instead, we rely on the explicit recomputation in _run_pull when moves are created.
+    @api.depends(
+        "qty_multiple",
+        "product_min_qty",
+        "product_max_qty",
+        "visibility_days",
+        "product_id",
+        "location_id",
+        "product_id.seller_ids.delay",
+    )
+    def _compute_qty_to_order_computed(self):
+        """Extend to add more depends values.
+        Backport from v19 to improve performance by storing computed qty_to_order.
+        """
+        return super()._compute_qty_to_order_computed()
+
+    # Improved search method without filtered_domain
+    def _search_qty_to_order(self, operator, value):
+        """Search method for qty_to_order that avoids filtered_domain performance issues.
+
+        This creates a more efficient domain that:
+        1. For manual orderpoints: checks qty_to_order_manual directly
+        2. For auto orderpoints: uses the stored qty_to_order_computed field
+        3. Combines both with OR logic to avoid loading all records
+        """
+        # For manual orderpoints (with qty_to_order_manual != 0), check qty_to_order_manual
+        manual_domain = [
+            "&",
+            ("qty_to_order_manual", "!=", 0),
+            ("qty_to_order_manual", operator, value),
+        ]
+
+        # For auto orderpoints (qty_to_order_manual = 0), check computed value
+        auto_domain = [
+            "&",
+            ("qty_to_order_manual", "=", 0),
+            ("qty_to_order_computed", operator, value),
+        ]
+
+        # Return domain that combines both cases
+        return ["|"] + manual_domain + auto_domain
 
     @api.depends("product_id", "location_id")
     def _compute_rotation(self):


### PR DESCRIPTION
backport v19 performance fixes and improve search for 'To Reorder' filter

Backports Odoo v19 performance improvements:
* Store qty_to_order_computed field for faster queries
* Add index on warehouse_id
* Recompute orderpoints when moves are created in _run_pull

for more info:
https://github.com/odoo/odoo/commit/6f2d1b26b34129cfbd62d2fe44f306bfe89794b5

Additional improvement beyond v19:
* Replace filtered_domain with SQL domain in _search_qty_to_order
  to avoid loading all orderpoints in memory

Includes migration scripts to create index and populate initial values.

Resolves database hangs and timeouts on large databases when filtering
orderpoints by 'To Reorder'.

