### PR TITLE
[FIX]stock_batch_picking_ux: assign book_id when validating a batch picking

### DIFF
--- a/stock_batch_picking_ux/i18n/es.po
+++ b/stock_batch_picking_ux/i18n/es.po
@@ -124,6 +124,12 @@ msgstr "Talonario de Remitos"
 #. module: stock_batch_picking_ux
 #. odoo-python
 #: code:addons/stock_batch_picking_ux/models/stock_batch_picking.py:0
+msgid "Please complete the vouchers book for the following pickings: %s"
+msgstr "Por favor completá los talonarios de remito en los siguientes traslados: %s"
+
+#. module: stock_batch_picking_ux
+#. odoo-python
+#: code:addons/stock_batch_picking_ux/models/stock_batch_picking.py:0
 msgid "The number of packages can not be 0"
 msgstr "El numero de bultos no puede ser 0"
 

--- a/stock_batch_picking_ux/models/stock_batch_picking.py
+++ b/stock_batch_picking_ux/models/stock_batch_picking.py
@@ -16,7 +16,7 @@ class StockPickingBatch(models.Model):
         # maneje en la vista para que si esta seteado pase dominio
         # y si no esta seteado no
         # required=True,
-        help="If you choose a partner then only pickings of this partner will" "be sellectable",
+        help="If you choose a partner then only pickings of this partner will be sellectable",
     )
     voucher_number = fields.Char()
     voucher_required = fields.Boolean(
@@ -112,10 +112,23 @@ class StockPickingBatch(models.Model):
             # al agregar la restriccion de que al menos una tenga que tener
             # cantidad entonces nunca se manda el force_qty al picking
             if all(operation.quantity == 0 for operation in rec.move_line_ids):
-                raise UserError(_("Debe definir Cantidad Realizada en al menos una " "operación."))
+                raise UserError(_("Debe definir Cantidad Realizada en al menos una operación."))
 
             if rec.restrict_number_package and not rec.number_of_packages > 0:
                 raise UserError(_("The number of packages can not be 0"))
+
+            if rec.picking_type_id.book_required:
+                if rec.picking_type_id.book_id:
+                    pickings_without_book = rec.picking_ids.filtered(lambda p: not p.book_id)
+                    pickings_without_book.book_id = rec.picking_type_id.book_id
+                else:
+                    pickings_without_book = rec.picking_ids.filtered(lambda p: not p.book_id)
+                    if pickings_without_book:
+                        raise UserError(
+                            _("Please complete the vouchers book for the following pickings: %s")
+                            % ", ".join(pickings_without_book.mapped("name"))
+                        )
+
             if rec.number_of_packages:
                 rec.picking_ids.write({"number_of_packages": rec.number_of_packages})
 
@@ -133,6 +146,20 @@ class StockPickingBatch(models.Model):
                             "name": rec.voucher_number,
                         }
                     )
+            else:
+                batch_voucher_installed = "stock_batch_picking_voucher" in self.env["ir.module.module"].search(
+                    [("name", "=", "stock_batch_picking_voucher"), ("state", "=", "installed")]
+                ).mapped("name")
+                if not batch_voucher_installed:
+                    for picking in rec.picking_ids:
+                        if not picking.picking_type_id.auto_print_delivery_slip:
+                            continue
+                        book = picking.book_id or picking.picking_type_id.book_id
+                        if not book:
+                            continue
+                        if all(operation.quantity == 0 for operation in picking.move_line_ids):
+                            continue
+                        picking.assign_numbers(picking.get_estimated_number_of_pages(), book)
         return super(StockPickingBatch, self.with_context(do_not_assign_numbers=True)).action_done()
 
     def action_view_stock_picking(self):


### PR DESCRIPTION
When validating a batch picking, the book_id field was not being assigned to the picking in case the book was required