### PR TITLE
[FIX] stock_declared_value + stock_ux: bugs v19 (product_uom_id rename + location context)

### DIFF
--- a/stock_declared_value/models/stock_picking.py
+++ b/stock_declared_value/models/stock_picking.py
@@ -43,18 +43,18 @@ class StockPicking(models.Model):
                     so_qty_done = move_line.quantity
                     # convert quantities if move line uom and sale line uom
                     # are different
-                    if move_line.product_uom != order_line.product_uom_id:
-                        so_product_qty = move_line.product_uom._compute_quantity(
+                    if move_line.product_uom_id != order_line.product_uom_id:
+                        so_product_qty = move_line.product_uom_id._compute_quantity(
                             move_line.product_uom_qty, order_line.product_uom_id
                         )
-                        so_qty_done = move_line.product_uom._compute_quantity(
+                        so_qty_done = move_line.product_uom_id._compute_quantity(
                             move_line.quantity, order_line.product_uom_id
                         )
                     picking_value += order_line.price_reduce_taxexcl * so_product_qty
                     done_value += order_line.price_reduce_taxexcl * so_qty_done
                 elif rec.picking_type_id.pricelist_id:
                     pricelist = rec.picking_type_id.pricelist_id
-                    price = rec.picking_type_id.pricelist_id.with_context(uom=move_line.product_uom.id)._price_get(
+                    price = rec.picking_type_id.pricelist_id.with_context(uom=move_line.product_uom_id.id)._price_get(
                         move_line.product_id, move_line.quantity or 1.0, partner=rec.partner_id.id
                     )[rec.picking_type_id.pricelist_id.id]
                     picking_value += price * move_line.product_uom_qty

--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.3.1",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -36,12 +36,18 @@ class StockMoveLine(models.Model):
         if not location:
             self.update({"product_uom_qty_location": 0.0})
             return False
-        # because now we use location_id to select location, we have compelte
-        # location name. If y need we can use some code of
-        # _get_domain_locations on stock/product.py
-        location_name = location[0]
-        if isinstance(location[0], int):
-            location_name = self.env["stock.location"].browse(location[0]).reference
+        # `location` puede venir como int (ID único), list/tuple de ints, o string.
+        # En v19 algunas vistas lo pasan como int directo → location[0] explota.
+        if isinstance(location, int):
+            location_name = self.env["stock.location"].browse(location).complete_name
+        elif isinstance(location, (list, tuple)):
+            first = location[0]
+            location_name = (
+                self.env["stock.location"].browse(first).complete_name
+                if isinstance(first, int) else first
+            )
+        else:
+            location_name = location  # string
         locations = self.env["stock.location"].search([("complete_name", "ilike", location_name)])
         for rec in self:
             product_uom_qty_location = rec.quantity


### PR DESCRIPTION
Dos fixes de compat v19 en este PR.

## 1. `stock_declared_value`: `move_line.product_uom` → `product_uom_id`

En v19 el campo `stock.move.line.product_uom` se renombró a `product_uom_id`. Cuatro accesos en `stock_declared_value/models/stock_picking.py` seguían usando el nombre viejo sobre un recordset `stock.move.line` (`move_line`), tirando `AttributeError` cuando corre `_compute_declared_value` post-migración.

Cambios en `_compute_declared_value`:
- `move_line.product_uom != order_line.product_uom_id` → `move_line.product_uom_id != order_line.product_uom_id`
- `move_line.product_uom._compute_quantity(...)` (dos llamadas) → `move_line.product_uom_id._compute_quantity(...)`
- `with_context(uom=move_line.product_uom.id)` → `with_context(uom=move_line.product_uom_id.id)`

Nota: `move_line.product_uom_qty` es un **Float distinto** que mantiene el mismo nombre en v19 y no se toca. Solo el Many2one `product_uom` / `product_uom_id` necesitaba el rename.

## 2. `stock_ux`: crash de `_compute_product_uom_qty_location` con location context

Dos bugs en `stock_ux/models/stock_move_line.py::_compute_product_uom_qty_location` que rompen cualquier vista de `stock.move.line` filtrada por location:

- `location[0]` asume list/tuple/str. En Odoo 19 algunas vistas lo pasan como `int` (ID único) → `TypeError: 'int' object is not subscriptable`. Ahora normaliza los 3 casos (int / list-tuple / str).
- `browse(id).reference` falla porque `stock.location` no tiene ese campo (en v18 tampoco existía, probablemente residuo de un rename viejo). Fijo a `.complete_name`, consistente con el `search([('complete_name', 'ilike', ...)])` de la línea siguiente.

Validado con ORM shell en DB v19 real (4 casos: int / list[int] / str / "").

## Test plan

- [x] Migrada DB de producción real (v18 → v19 via upgrade.odoo.com) con `stock_declared_value` y `stock_ux` instalados.
- [x] Pickings con declared value y move_lines con UoMs distintas calculan la cantidad correcta post-fix.
- [x] Vistas `stock.move.line` filtradas por location (selector → location específica) cargan sin crash.

Module version bumps:
- `stock_declared_value`: (commit previo)
- `stock_ux`: `19.0.1.3.0 → 19.0.1.3.1`
