### PR TITLE
[IMP] stock_voucher_ux: add translations for error msgs and sequence_to field

### DIFF
--- a/stock_voucher_ux/i18n/es.po
+++ b/stock_voucher_ux/i18n/es.po
@@ -43,6 +43,12 @@ msgid "Clean Voucher Data"
 msgstr "Limpiar Remitos"
 
 #. module: stock_voucher_ux
+#. odoo-python
+#: code:addons/stock_voucher_ux/models/stock_picking.py:0
+msgid "The voucher number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range."
+msgstr "El número de remito %s excede el rango especificado en el CAI. Actualice el rango o utilice otro CAI con un rango diferente."
+
+#. module: stock_voucher_ux
 #: model:ir.model.fields,help:stock_voucher_ux.field_stock_book__autoprinted
 #: model:ir.model.fields,help:stock_voucher_ux.field_stock_picking__autoprinted
 msgid ""
@@ -89,6 +95,11 @@ msgstr "Imprimir Remitos"
 #: model:ir.model.fields,field_description:stock_voucher_ux.field_stock_picking__printed
 msgid "Printed"
 msgstr "Impreso"
+
+#. module: stock_voucher_ux
+#: model:ir.model.fields,field_description:stock_voucher_ux.field_stock_book__sequence_to
+msgid "Sequence To"
+msgstr "Secuencia Hasta"
 
 #. module: stock_voucher_ux
 #: model:ir.model,name:stock_voucher_ux.model_stock_book

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -44,7 +44,7 @@ class StockPicking(models.Model):
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
                 raise UserError(
-                    self.env._(
+                    _(
                         "The voucher number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range.",
                         self.next_voucher_number,
                     )


### PR DESCRIPTION
Agregamos traducciones al campo "Sequence To" y el mensaje de error relacionado con la secuencia. Dejo capturas
<img width="1510" height="585" alt="image" src="https://github.com/user-attachments/assets/b34c83aa-2c6d-406a-99ea-c40d0ebff3d7" />

<img width="959" height="650" alt="image" src="https://github.com/user-attachments/assets/4d0c55c7-bf85-44cd-9128-95389a7c8673" />
