### PR TITLE
[FIX] stock_batch_picking_voucher: asignar números de remitos antes de imprimir

### DIFF
--- a/stock_batch_picking_voucher/__manifest__.py
+++ b/stock_batch_picking_voucher/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Preprinted report in batch pickings",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_batch_picking_voucher/models/stock_picking_batch.py
+++ b/stock_batch_picking_voucher/models/stock_picking_batch.py
@@ -72,13 +72,10 @@ class StockPickingBatch(models.Model):
             rec.with_vouchers = bool(self.voucher_ids)
 
     def do_print_and_assign(self):
-        # We override the method to avoid assignation
         if not self.book_id:
             raise UserError("Primero debe setear un talonario")
-        if not self.book_id.autoprinted:
-            self.printed = True
-            return self.with_context(batch=True).do_print_batch_vouchers()
-        self.assign_numbers(1, self.book_id)
+        pages = 1 if self.book_id.autoprinted else (self.estimated_number_of_pages or 1)
+        self.assign_numbers(pages, self.book_id)
         return self.do_print_batch_vouchers()
 
     def do_print_batch_vouchers(self):


### PR DESCRIPTION
## Summary

- Se corrige el flujo en `do_print_and_assign` del modelo `stock.picking.batch`: antes, cuando el talonario **no** era autoprinted (numeración por sistema), el número de remito se asignaba *después* de generar el PDF (via el controlador HTTP), por lo que la primera impresión salía sin número.
- Ahora el número se asigna **antes** de imprimir, usando `estimated_number_of_pages` (o 1 si no está definido), de modo que la primera impresión ya contiene el número de remito.

## Tarea relacionada

https://www.adhoc.inc/odoo/my-tasks/67613

## Test plan

- [ ] Configurar un lote de transferencias con talonario **no** autoprinted.
- [ ] Hacer click en "Imprimir Remitos" desde un lote en estado `done`.
- [ ] Verificar que el PDF generado ya incluye el número de remito asignado (primera impresión).
- [ ] Verificar que al re-imprimir, el número no cambia (no se asigna dos veces).