### PR TITLE
[FIX] stock_voucher_ux: asignar números de remito antes de imprimir

### DIFF
--- a/stock_voucher/models/stock_picking.py
+++ b/stock_voucher/models/stock_picking.py
@@ -58,7 +58,7 @@ class StockPicking(models.Model):
         if lines_per_voucher == 0:
             return res
 
-        operations = len(self.move_ids)
+        operations = len(self.move_line_ids)
         res = int(-(-float(operations) // float(lines_per_voucher)))
         return res
 

--- a/stock_voucher_ux/__manifest__.py
+++ b/stock_voucher_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Voucher UX",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -107,36 +107,47 @@ class ReportController(report.ReportController):
             match = re.search(r"(\d+)$", json.loads(data)[0])
             if match:
                 picking_id = int(match.group(1))
-                book_id = request.env["stock.picking"].browse(picking_id).book_id
+                picking = request.env["stock.picking"].browse(picking_id)
+                book_id = picking.book_id
                 if book_id and book_id.autoprinted == False and picking_id:
-                    try:
-                        pdf_response = response.response[0]
-                        reader = PdfFileReader(io.BytesIO(pdf_response))
+                    if not picking.voucher_ids and book_id:
+                        try:
+                            pdf_response = response.response[0]
+                            reader = PdfFileReader(io.BytesIO(pdf_response))
 
-                        # Usar el nuevo método para contar páginas con productos
-                        copies_result = request.env["ir.actions.report"].search_read(
-                            [("report_name", "=", "stock.report_deliveryslip")], ["l10n_ar_copies"], limit=1
-                        )
-                        copies = copies_result[0]["l10n_ar_copies"] if copies_result else None
+                            # Usar el nuevo método para contar páginas con productos
+                            copies_result = request.env["ir.actions.report"].search_read(
+                                [("report_name", "=", "stock.report_deliveryslip")], ["l10n_ar_copies"], limit=1
+                            )
+                            copies = copies_result[0]["l10n_ar_copies"] if copies_result else None
 
-                        if copies == "triplicado":
-                            total_pages = int(len(reader.pages) / 3)
-                        elif copies == "duplicado":
-                            total_pages = int(len(reader.pages) / 2)
-                        else:
-                            total_pages = len(reader.pages)
+                            if copies == "triplicado":
+                                total_pages = int(len(reader.pages) / 3)
+                            elif copies == "duplicado":
+                                total_pages = int(len(reader.pages) / 2)
+                            else:
+                                total_pages = len(reader.pages)
 
-                        number_pages = self._count_pages_with_products(reader, picking_id)
-                        number_pages = min(number_pages, total_pages)
-                    except Exception:
-                        # If not PDF or can't process, assign only 1 voucher
-                        number_pages = 1
+                            number_pages = self._count_pages_with_products(reader, picking_id)
+                            number_pages = min(number_pages, total_pages)
+                        except Exception:
+                            # If not PDF or can't process, assign only 1 voucher
+                            number_pages = 1
 
-                    if not request.env["stock.picking"].browse(picking_id).voucher_ids and book_id:
-                        request.env["stock.picking"].browse(picking_id).assign_numbers(number_pages, book_id)
+                        picking.assign_numbers(number_pages, book_id)
+
+                        # Regenerate PDF so voucher numbers appear on the first print
+                        try:
+                            new_pdf, _ = request.env["ir.actions.report"]._render_qweb_pdf(
+                                "stock.report_deliveryslip", picking.ids
+                            )
+                            response.response = [new_pdf]
+                            response.headers["Content-Length"] = str(len(new_pdf))
+                        except Exception:
+                            pass
 
                 elif book_id and picking_id:
-                    if not request.env["stock.picking"].browse(picking_id).voucher_ids and book_id:
-                        request.env["stock.picking"].browse(picking_id).assign_numbers(1, book_id)
+                    if not picking.voucher_ids and book_id:
+                        picking.assign_numbers(1, book_id)
 
         return response

--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -137,14 +137,11 @@ class ReportController(report.ReportController):
                         picking.assign_numbers(number_pages, book_id)
 
                         # Regenerate PDF so voucher numbers appear on the first print
-                        try:
-                            new_pdf, _ = request.env["ir.actions.report"]._render_qweb_pdf(
-                                "stock.report_deliveryslip", picking.ids
-                            )
-                            response.response = [new_pdf]
-                            response.headers["Content-Length"] = str(len(new_pdf))
-                        except Exception:
-                            pass
+                        new_pdf, _ = request.env["ir.actions.report"]._render_qweb_pdf(
+                            "stock.action_report_delivery", picking.ids
+                        )
+                        response.response = [new_pdf]
+                        response.headers["Content-Length"] = str(len(new_pdf))
 
                 elif book_id and picking_id:
                     if not picking.voucher_ids and book_id:

--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -135,6 +135,9 @@ class ReportController(report.ReportController):
                             number_pages = 1
 
                         picking.assign_numbers(number_pages, book_id)
+                        # Flush pending ORM writes (computed store=True fields like
+                        # 'vouchers') to DB so the re-render reads the updated values.
+                        picking.env.flush_all()
 
                         # Regenerate PDF so voucher numbers appear on the first print
                         new_pdf, _ = request.env["ir.actions.report"]._render_qweb_pdf(

--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -103,7 +103,10 @@ class ReportController(report.ReportController):
                     request.env["stock.picking"].browse(picking_id).assign_numbers(number_pages, book_id)
 
         elif "report_deliveryslip" in url:
-            # If the report is not an aeroo, the assign method should only assign one voucher
+            # Fallback: if numbers weren't pre-assigned (e.g. printed outside
+            # do_print_and_assign), assign them post-render based on actual page count.
+            # Note: in this path the first PDF won't show the numbers; use
+            # do_print_and_assign to guarantee numbers on the first print.
             match = re.search(r"(\d+)$", json.loads(data)[0])
             if match:
                 picking_id = int(match.group(1))
@@ -115,7 +118,6 @@ class ReportController(report.ReportController):
                             pdf_response = response.response[0]
                             reader = PdfFileReader(io.BytesIO(pdf_response))
 
-                            # Usar el nuevo método para contar páginas con productos
                             copies_result = request.env["ir.actions.report"].search_read(
                                 [("report_name", "=", "stock.report_deliveryslip")], ["l10n_ar_copies"], limit=1
                             )
@@ -131,20 +133,9 @@ class ReportController(report.ReportController):
                             number_pages = self._count_pages_with_products(reader, picking_id)
                             number_pages = min(number_pages, total_pages)
                         except Exception:
-                            # If not PDF or can't process, assign only 1 voucher
                             number_pages = 1
 
                         picking.assign_numbers(number_pages, book_id)
-                        # Flush pending ORM writes (computed store=True fields like
-                        # 'vouchers') to DB so the re-render reads the updated values.
-                        picking.env.flush_all()
-
-                        # Regenerate PDF so voucher numbers appear on the first print
-                        new_pdf, _ = request.env["ir.actions.report"]._render_qweb_pdf(
-                            "stock.action_report_delivery", picking.ids
-                        )
-                        response.response = [new_pdf]
-                        response.headers["Content-Length"] = str(len(new_pdf))
 
                 elif book_id and picking_id:
                     if not picking.voucher_ids and book_id:

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -39,8 +39,10 @@ class StockPicking(models.Model):
         if not self.book_id and self.picking_type_code != "incoming":
             raise UserError("Primero debe seleccionar un talonario")
         if self.autoprinted == False:
+            if self.book_id and not self.voucher_ids:
+                self.assign_numbers(self.get_estimated_number_of_pages(), self.book_id)
             self.printed = True
-            return self.with_context(assign=True).do_print_voucher()
+            return self.do_print_voucher()
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
                 raise UserError(

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -39,8 +39,10 @@ class StockPicking(models.Model):
         if not self.book_id and self.picking_type_code != "incoming":
             raise UserError("Primero debe seleccionar un talonario")
         if self.autoprinted == False:
+            if self.book_id:
+                self.assign_numbers(self.get_estimated_number_of_pages(), self.book_id)
             self.printed = True
-            return self.with_context(assign=True).do_print_voucher()
+            return self.do_print_voucher()
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
                 raise UserError(

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -39,10 +39,8 @@ class StockPicking(models.Model):
         if not self.book_id and self.picking_type_code != "incoming":
             raise UserError("Primero debe seleccionar un talonario")
         if self.autoprinted == False:
-            if self.book_id:
-                self.assign_numbers(self.get_estimated_number_of_pages(), self.book_id)
             self.printed = True
-            return self.do_print_voucher()
+            return self.with_context(assign=True).do_print_voucher()
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
                 raise UserError(


### PR DESCRIPTION
## Problema

Al usar el botón **Print Vouchers** en un remito con `autoprinted=False` (formulario pre-impreso), los números de remito se asignaban *después* de generar el PDF (en el controller HTTP), por lo que la primera impresión salía sin número. El usuario tenía que imprimir dos veces.

## Solución

En `do_print_and_assign`, para el caso `autoprinted=False`, se llama `assign_numbers(get_estimated_number_of_pages(), book_id)` **antes** de invocar `do_print_voucher()`, igual que el flujo de `autoprinted=True`.

El controller conserva la guarda `if not voucher_ids` que evita doble asignación cuando ya fueron pre-asignados.

## Task

https://www.adhoc.inc/odoo/knowledge/180/902/tasks/67613