### PR TITLE
[FIX] stock_ux: remover context group_by del search field product_id en stock.move.line

### DIFF
--- a/stock_ux/views/stock_move_line_views.xml
+++ b/stock_ux/views/stock_move_line_views.xml
@@ -23,7 +23,7 @@
                 <field name="origin"/>
             </field>
             <field name="location_id" position="before">
-                <field name="product_id" string="Product" context="{'group_by':'product_id'}"/>
+                <field name="product_id" string="Product"/>
                 <field name="location_id" string="Net Quantity Location" filter_domain="['|',('location_id','ilike',self),('location_dest_id','ilike',self)]" context="{'location': self}"/>
             </field>
             <filter name="manufacturing" position="after">


### PR DESCRIPTION
## Problema

Al aplicar groupby (Location, Product, Date:month) y filtrar por producto en la vista **Movimientos de Productos Detallados** (`stock.move.line`), guardar el resultado como favorito y recargar producía:

```
ValueError: Invalid field 'p' on model 'stock.move.line'
```

## Causa raíz

El search view de `stock_ux` tenía:
```xml
<field name="product_id" string="Product" context="{'group_by':'product_id'}"/>
```

Al filtrar por producto usando este campo, `_getSearchItemContext` en `search_model.js` evaluaba el `context` del `<field>` e inyectaba `group_by: 'product_id'` (string) en el contexto de búsqueda. Al guardar el favorito, la línea del core:
```javascript
context: { group_by: groupBys, ...context }   // search_model.js
```
dejaba que el spread `...context` sobrescribiera el array `groupBys` con el string `'product_id'`. El `ir.filters` quedaba guardado con `group_by: 'product_id'` como string en lugar del array correcto.

Al recargar el favorito, `push(...'product_id')` iteraba el string carácter a carácter: el backend recibía `groupby = ['p', 'r', 'o', ...]` y fallaba en `'p'`.

## Fix

Remover el `context` del `<field name="product_id">` en el search view. El groupby por producto ya está definido como `<filter name="groupby_product_id" context="{'group_by': 'product_id'}"/>` en la vista base de Odoo stock — el atributo en el `<field>` era redundante y causaba la corrupción del favorito.

## Notas

- Afecta a clientes con favoritos guardados en ese estado: necesitan eliminar manualmente el `ir.filters` corrupto (model `stock.move.line`, `group_by` como string en el context).
- El bug latente en `search_model.js` (orden del spread) es un issue de Odoo upstream.

Closes #119325