### PR TITLE
[ADD] stock_delivery_zone: backport from 19.0 to 18.0

### DIFF
--- a/stock_delivery_zone/__init__.py
+++ b/stock_delivery_zone/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import models

--- a/stock_delivery_zone/__manifest__.py
+++ b/stock_delivery_zone/__manifest__.py
@@ -1,0 +1,43 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Delivery Zone",
+    "version": "18.0.1.0.0",
+    "category": "Warehouse Management",
+    "summary": "Assign delivery zones to contacts and show them on transfers",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "contacts",
+        "stock_ux",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/stock_delivery_zone_views.xml",
+        "views/res_partner_views.xml",
+        "views/stock_picking_views.xml",
+        "report/stock_picking_reports.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/stock_delivery_zone/i18n/es.po
+++ b/stock_delivery_zone/i18n/es.po
@@ -1,0 +1,101 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_delivery_zone
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 13:00+0000\n"
+"PO-Revision-Date: 2026-06-09 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Spanish (https://app.transifex.com/adhoc/teams/46451/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_picking_ux
+msgid "<strong>Zone:</strong>"
+msgstr "<strong>Zona:</strong>"
+
+#. module: stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_delivery_document
+msgid "<strong>Zone</strong>"
+msgstr "<strong>Zona</strong>"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_date
+msgid "Created on"
+msgstr "Fecha de creación"
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_stock_delivery_zone
+msgid "Delivery Zone"
+msgstr "Zona de entrega"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__display_name
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__display_name
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__id
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_date
+msgid "Last Updated on"
+msgstr "Última actualización"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_stock_picking
+msgid "Transfer"
+msgstr "Transferencia"
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__delivery_zone_id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_users__delivery_zone_id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__delivery_zone_id
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_form
+msgid "Zone"
+msgstr "Zona"
+
+#. module: stock_delivery_zone
+#: model:ir.actions.act_window,name:stock_delivery_zone.stock_delivery_zone_action_stock_delivery_zone
+#: model:ir.ui.menu,name:stock_delivery_zone.stock_delivery_zone_menu_stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_list
+msgid "Zones"
+msgstr "Zonas"

--- a/stock_delivery_zone/i18n/stock_delivery_zone.pot
+++ b/stock_delivery_zone/i18n/stock_delivery_zone.pot
@@ -1,0 +1,100 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_delivery_zone
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 13:00+0000\n"
+"PO-Revision-Date: 2026-06-02 13:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_picking_ux
+msgid "<strong>Zone:</strong>"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_delivery_document
+msgid "<strong>Zone</strong>"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__active
+msgid "Active"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_stock_delivery_zone
+msgid "Delivery Zone"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__display_name
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__display_name
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__name
+msgid "Name"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model,name:stock_delivery_zone.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__delivery_zone_id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_res_users__delivery_zone_id
+#: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__delivery_zone_id
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_form
+msgid "Zone"
+msgstr ""
+
+#. module: stock_delivery_zone
+#: model:ir.actions.act_window,name:stock_delivery_zone.stock_delivery_zone_action_stock_delivery_zone
+#: model:ir.ui.menu,name:stock_delivery_zone.stock_delivery_zone_menu_stock_delivery_zone
+#: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_list
+msgid "Zones"
+msgstr ""

--- a/stock_delivery_zone/models/__init__.py
+++ b/stock_delivery_zone/models/__init__.py
@@ -1,0 +1,8 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import delivery_zone
+from . import res_partner
+from . import stock_picking

--- a/stock_delivery_zone/models/delivery_zone.py
+++ b/stock_delivery_zone/models/delivery_zone.py
@@ -1,0 +1,15 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import fields, models
+
+
+class StockDeliveryZone(models.Model):
+    _name = "stock.delivery.zone"
+    _description = "Delivery Zone"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True)

--- a/stock_delivery_zone/models/res_partner.py
+++ b/stock_delivery_zone/models/res_partner.py
@@ -1,0 +1,16 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    delivery_zone_id = fields.Many2one(
+        comodel_name="stock.delivery.zone",
+        string="Zone",
+        ondelete="set null",
+    )

--- a/stock_delivery_zone/models/stock_picking.py
+++ b/stock_delivery_zone/models/stock_picking.py
@@ -1,0 +1,18 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    delivery_zone_id = fields.Many2one(
+        comodel_name="stock.delivery.zone",
+        related="partner_id.delivery_zone_id",
+        string="Zone",
+        readonly=True,
+        ondelete="set null",
+    )

--- a/stock_delivery_zone/report/stock_picking_reports.xml
+++ b/stock_delivery_zone/report/stock_picking_reports.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="stock_delivery_zone_report_delivery_document" inherit_id="stock_ux.report_delivery_document">
+        <xpath expr="//div[@name='outgoing_delivery_address']/div" position="after">
+            <div t-if="o.delivery_zone_id">
+                <strong>Zone</strong>
+                <div t-field="o.delivery_zone_id"/>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="stock_delivery_zone_report_picking_ux" inherit_id="stock_ux.report_picking_ux">
+        <xpath expr="//div[@name='div_outgoing_address']/div[@t-if='o.should_print_delivery_address()']/div" position="after">
+            <div t-if="o.delivery_zone_id">
+                <strong>Zone:</strong>
+                <div t-field="o.delivery_zone_id"/>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/stock_delivery_zone/security/ir.model.access.csv
+++ b/stock_delivery_zone/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_delivery_zone_user,stock.delivery.zone user,model_stock_delivery_zone,base.group_user,1,0,0,0
+access_stock_delivery_zone_system,stock.delivery.zone system,model_stock_delivery_zone,base.group_system,1,1,1,1

--- a/stock_delivery_zone/views/res_partner_views.xml
+++ b/stock_delivery_zone/views/res_partner_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_delivery_zone_view_res_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form.stock.delivery.zone</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//span[@name='address_name']/following-sibling::div[hasclass('o_address_format')]" position="after">
+                <field name="delivery_zone_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_delivery_zone/views/stock_delivery_zone_views.xml
+++ b/stock_delivery_zone/views/stock_delivery_zone_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_delivery_zone_view_stock_delivery_zone_list" model="ir.ui.view">
+        <field name="name">stock.delivery.zone.list</field>
+        <field name="model">stock.delivery.zone</field>
+        <field name="arch" type="xml">
+            <list string="Zones">
+                <field name="name"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="stock_delivery_zone_view_stock_delivery_zone_form" model="ir.ui.view">
+        <field name="name">stock.delivery.zone.form</field>
+        <field name="model">stock.delivery.zone</field>
+        <field name="arch" type="xml">
+            <form string="Zone">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="active"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="stock_delivery_zone_action_stock_delivery_zone" model="ir.actions.act_window">
+        <field name="name">Zones</field>
+        <field name="res_model">stock.delivery.zone</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem
+        id="stock_delivery_zone_menu_stock_delivery_zone"
+        name="Zones"
+        parent="contacts.res_partner_menu_config"
+        action="stock_delivery_zone_action_stock_delivery_zone"
+        sequence="7"
+    />
+</odoo>

--- a/stock_delivery_zone/views/stock_picking_views.xml
+++ b/stock_delivery_zone/views/stock_picking_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_delivery_zone_view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.stock.delivery.zone</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="delivery_zone_id" readonly="1" invisible="picking_type_code != 'outgoing'"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Backport of `stock_delivery_zone` module from 19.0 to 18.0
- Only change from upstream: version bump `19.0.1.0.0` → `18.0.1.0.0`
- Added Spanish translation (`i18n/es.po`)
- Report xpaths verified against Odoo 18 core — both `div[@name='outgoing_delivery_address']` and `div[@name='div_outgoing_address']` exist with the same structure