### PR TITLE
[FIX] stock_ux: skip manual lines check on manual action_assign

### DIFF
--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -139,6 +139,15 @@ class StockMove(models.Model):
             return super().with_context(trigger_assign=True)._trigger_assign()
         return super()._trigger_assign()
 
+    def _action_assign(self, force_qty=False):
+        """Reservar / Comprobar disponibilidad crea líneas de reserva, no líneas
+        cargadas a mano, por lo que no debe dispararse el chequeo de
+        _check_manual_lines. El _trigger_assign automático ya lo evitaba, pero el
+        action_assign manual del picking no pasaba por ahí; marcamos el contexto
+        para saltear _check_quantity_available al crear las stock.move.line.
+        """
+        return super(StockMove, self.with_context(trigger_assign=True))._action_assign(force_qty=force_qty)
+
     @api.ondelete(at_uninstall=False)
     def _unlink_if_not_from_order(self):
         """


### PR DESCRIPTION
### Problem

Pressing **Check availability** (`action_assign`) on a picking could wrongly raise:

> You can't transfer more quantity than the quantity on stock!

`_check_manual_lines` (in `stock.move.line.create`) runs `_check_quantity_available`, which is meant to block users from **manually** loading more quantity than available. That check is bypassed when the reservation comes from the automatic `_trigger_assign` (it sets the `trigger_assign` context key).

But the **manual** `action_assign` button goes straight to `stock.move._action_assign()` without that context, so when the source location has a negative available quantity (e.g. a leftover negative quant), assigning creates reservation move lines whose `_check_quantity_available()` is negative and the validation fires — even though `action_assign` is not loading manual lines, just reserving.

### Fix

Override `stock.move._action_assign` to set `trigger_assign=True` in context, mirroring `_trigger_assign`. Reservation (manual or automatic) now consistently bypasses `_check_quantity_available`, while manual edits on move lines remain blocked as before.