### PR TITLE
[FIX] stock_orderpoint_manual_update: keep qty_forecast in DOM to avoid XPath conflict with Studio

### DIFF
--- a/stock_orderpoint_manual_update/__manifest__.py
+++ b/stock_orderpoint_manual_update/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Orderpoint Manual Update",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_orderpoint_manual_update/views/stock_warehouse_orderpoint_views.xml
+++ b/stock_orderpoint_manual_update/views/stock_warehouse_orderpoint_views.xml
@@ -6,7 +6,10 @@
         <field name="model">stock.warehouse.orderpoint</field>
         <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable"/>
         <field name="arch" type="xml">
-            <field name="qty_forecast" position="replace">
+            <field name="qty_forecast" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+            <field name="qty_forecast" position="after">
                 <field name="qty_forecast_stored"/>
             </field>
         </field>


### PR DESCRIPTION
## Problem

When Studio is used on the `stock.warehouse.orderpoint` list view, it raises:

```
ValueError: El elemento "<xpath expr="//field[@name='qty_forecast']">" no se puede localizar en la vista principal
```

This happens because `stock_orderpoint_manual_update` used `position="replace"` to remove `qty_forecast` from the DOM entirely and substitute it with `qty_forecast_stored`. A sibling inherited view (`stock.warehouse.orderpoint.tree.inherit`) anchors its XPath on `//field[@name='qty_forecast']`. When Studio's `apply_inheritance_specs` override processes the view combination and applies the sibling view after the replace, the anchor no longer exists — raising the error.

## Fix

Replace `position="replace"` with `position="attributes"` (making the field invisible instead of removing it from the DOM), then add `qty_forecast_stored` via a separate `position="after"`. This keeps `qty_forecast` as a valid XPath anchor while hiding it from the UI.

```xml
<!-- before -->
<field name="qty_forecast" position="replace">
    <field name="qty_forecast_stored"/>
</field>

<!-- after -->
<field name="qty_forecast" position="attributes">
    <attribute name="column_invisible">1</attribute>
</field>
<field name="qty_forecast" position="after">
    <field name="qty_forecast_stored"/>
</field>
```