### PR TITLE
[FIX] stock_batch_picking_ux: reset quantities to zero only on reception batches

### DIFF
--- a/stock_batch_picking_ux/__manifest__.py
+++ b/stock_batch_picking_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Usability with Batch Picking and stock vouchers",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.3.1",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_batch_picking_ux/models/stock_batch_picking.py
+++ b/stock_batch_picking_ux/models/stock_batch_picking.py
@@ -97,11 +97,13 @@ class StockPickingBatch(models.Model):
         batches_in_draft = self.filtered(lambda batch: batch.state == "draft")
         res = super().action_confirm()
         # When the batch is confirmed for the first time, Odoo already created
-        # the operation lines from the selected pickings. We reset them to zero
-        # so the operator can input only the quantities that will actually be processed.
-        batches_in_draft.move_line_ids.filtered(lambda line: line.state not in ("done", "cancel")).write(
-            {"quantity": 0}
-        )
+        # the operation lines from the selected pickings. For receptions we reset
+        # them to zero so the operator can input only the quantities physically
+        # received (partial reception). This must NOT touch deliveries/waves,
+        # where zeroing the quantity wrongly removes product availability.
+        batches_in_draft.move_line_ids.filtered(
+            lambda line: line.state not in ("done", "cancel") and line.picking_id.picking_type_id.code == "incoming"
+        ).write({"quantity": 0})
         return res
 
     def add_picking_operation(self):


### PR DESCRIPTION
## Problema (ticket 120763)

Al armar olas/entregas (pickings de salida) agrupando pedidos en un `stock.picking.batch`, los pedidos quedaban con **disponibilidad 0** y pasaban de "a procesar" a "en espera", bloqueando el pickeo.

## Causa

El override de `action_confirm()` agregado en la tarea **68226** (RF-02) reseteaba `quantity = 0` en **todas** las líneas del batch al confirmar. Esa inicialización en cero estaba pensada **solo para recepciones parciales** (RF-02 original: "Inicialización de Cantidades en Cero para Recepciones Parciales"), pero se aplicaba también a entregas y movimientos internos, quitándoles la cantidad reservada.

## Fix

Restringir el reseteo a líneas de pickings de recepción (`picking_type_id.code == 'incoming'`). Entregas/olas y movimientos internos ya no se tocan.

## Cómo probar

- Armar una ola de **entregas** con pedidos disponibles → confirmar el batch → la disponibilidad se mantiene (ya no va a 0).
- Armar un batch de **recepción** parcial → confirmar → sigue inicializando en 0 (comportamiento RF-02 intacto).

Relacionado: tarea 68226 (desarrollo original), PR #940 (ya mergeado).