### PR TITLE
[ADD] stock_ux: inventory adjustments permission group

### DIFF
--- a/stock_ux/migrations/19.0.1.12.0/post-migration.py
+++ b/stock_ux/migrations/19.0.1.12.0/post-migration.py
@@ -1,0 +1,21 @@
+import logging
+
+from openupgradelib import openupgrade
+
+logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """The "Inventory Adjustments" capability was carved out of the plain
+    Inventory User group. To avoid a regression on existing installations,
+    grant the new group to every user that is currently an Inventory User so
+    they keep being able to adjust. Admins can then untick it for the users
+    that should become "basic" (everything but adjustments)."""
+    adjustment_group = env.ref("stock_ux.group_stock_inventory_adjustment", raise_if_not_found=False)
+    stock_user_group = env.ref("stock.group_stock_user", raise_if_not_found=False)
+    if not adjustment_group or not stock_user_group:
+        return
+    users = stock_user_group.all_user_ids
+    logger.info("Granting 'Inventory Adjustments' to %s existing Inventory Users", len(users))
+    adjustment_group.write({"user_ids": [(4, user.id) for user in users]})

--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -15,3 +15,4 @@ from . import stock_rule
 from . import stock_scrap
 from . import stock_location
 from . import stock_forecasted
+from . import stock_quant

--- a/stock_ux/models/stock_quant.py
+++ b/stock_ux/models/stock_quant.py
@@ -1,0 +1,20 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    def _is_inventory_mode(self):
+        """Inventory adjustments are no longer granted by being a plain
+        Inventory User. The "inventory session" mode (the one that creates the
+        stock.move backing an adjustment) now requires the dedicated
+        ``group_stock_inventory_adjustment`` group, so an Inventory User
+        without it cannot apply adjustments even if it reaches an editable
+        quant view."""
+        return self.env.context.get("inventory_mode") and self.env.user.has_group(
+            "stock_ux.group_stock_inventory_adjustment"
+        )

--- a/stock_ux/security/stock_ux_security.xml
+++ b/stock_ux/security/stock_ux_security.xml
@@ -17,4 +17,35 @@
         <field name="name">Restrict editing Operation Type in Pickings</field>
     </record>
 
+    <!-- Inventory adjustments capability, carved out of the plain Inventory User.
+         An independent group (no privilege_id) so it shows as a standalone
+         checkbox. A plain Inventory User without it is the "basic" user that
+         can do everything but inventory adjustments. -->
+    <record model="res.groups" id="group_stock_inventory_adjustment">
+        <field name="name">Inventory Adjustments</field>
+        <field name="comment">Allows the user to perform inventory adjustments (physical inventory counts and on-hand quantity updates).</field>
+    </record>
+
+    <!-- Inventory Managers must always be able to adjust. -->
+    <record model="res.groups" id="stock.group_stock_manager">
+        <field name="implied_ids" eval="[(4, ref('stock_ux.group_stock_inventory_adjustment'))]"/>
+    </record>
+
+    <!-- The plain Inventory User keeps read-only access on quants; write/create
+         (i.e. applying an adjustment) is moved to the adjustment group below. -->
+    <record model="ir.model.access" id="stock.access_stock_quant_user">
+        <field name="perm_write" eval="0"/>
+        <field name="perm_create" eval="0"/>
+    </record>
+
+    <record model="ir.model.access" id="access_stock_quant_adjustment">
+        <field name="name">stock.quant inventory adjustment</field>
+        <field name="model_id" ref="stock.model_stock_quant"/>
+        <field name="group_id" ref="stock_ux.group_stock_inventory_adjustment"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="0"/>
+    </record>
+
 </odoo>

--- a/stock_ux/views/stock_quant_views.xml
+++ b/stock_ux/views/stock_quant_views.xml
@@ -10,4 +10,16 @@
             </xpath>
         </field>
     </record>
+
+    <!-- Move the inventory adjustment entry points to the adjustment group so a
+         plain Inventory User no longer sees them. "Set to 0" and "Relocate" are
+         already manager-only in core, and "Inventory" / "Locations"
+         (action_view_quants, read-only) stays on group_stock_user on purpose. -->
+    <record model="ir.actions.server" id="stock.action_view_inventory_tree">
+        <field name="group_ids" eval="[(6, 0, [ref('stock_ux.group_stock_inventory_adjustment')])]"/>
+    </record>
+
+    <record model="ir.actions.server" id="stock.action_view_set_quants_tree">
+        <field name="group_ids" eval="[(6, 0, [ref('stock_ux.group_stock_inventory_adjustment')])]"/>
+    </record>
 </odoo>


### PR DESCRIPTION
## What

Adds a dedicated **"Inventory Adjustments"** permission group so an
Inventory User can be restricted from performing inventory adjustments
(physical inventory counts and on-hand quantity updates) while keeping
every other Inventory User capability (pickings, moves, etc.).

Inventory adjustments in Odoo are granted implicitly by the plain
Inventory User group (`stock.group_stock_user`): it carries `write`/
`create` on `stock.quant` and gates the adjustment menu/actions. Since
groups are additive there is no way to express "User minus adjustments"
by subtraction, so this PR carves the capability out into its own group.

## How

- New independent group `group_stock_inventory_adjustment` (standalone
  checkbox, no privilege). `stock.group_stock_manager` implies it, so
  managers keep adjusting.
- `stock.quant` `write`/`create` access moved from `group_stock_user`
  (now read-only) to the new group. Normal stock operations are
  unaffected — moves update quants in sudo.
- `stock.quant._is_inventory_mode()` overridden to require the new
  group, so the backing inventory `stock.move` is only created for users
  allowed to adjust (defense in depth on top of the ACL).
- Adjustment server actions (`action_view_inventory_tree` – Physical
  Inventory, `action_view_set_quants_tree` – Set to quantity on hand)
  re-gated to the new group.
- Post-migration grants the new group to all existing Inventory Users to
  avoid a regression; admins can then untick it for "basic" users.

## Resulting behavior

- **Inventory User** without the checkbox → everything but adjustments.
- **Inventory User + Inventory Adjustments** → same as today's user.
- **Inventory Manager** → always allowed (implies the group).

## Test plan

1. Update the module on a DB with existing Inventory Users → they keep
   the adjustment capability (migration).
2. Create a user with Inventory = User and no "Inventory Adjustments":
   - Physical Inventory menu is hidden; cannot apply `inventory_quantity`.
   - Can still validate a delivery/receipt and see on-hand by location.
3. Tick "Inventory Adjustments" → Physical Inventory appears and
   adjustments can be applied again.
