### PR TITLE
[FIX] stock_ux: allow return moves when block_additional_quantity is set

### DIFF
--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -115,7 +115,7 @@ class StockMove(models.Model):
                 and sp.sale_id
                 and (sp.sale_id.state == "sale" or sp.sale_id.state == "done")
             ):
-                if vals.get("additional", False):
+                if vals.get("additional", False) and not vals.get("origin_returned_move_id"):
                     raise UserError(
                         "No se puede agregar productos adicionales ni modificar las cantidades demandadas:\n"
                         "- El pedido de venta se encuentra bloqueado.\n"


### PR DESCRIPTION
Return moves created by the return wizard have `additional=True` (inherited via `copy=True`) and `origin_returned_move_id` set. The existing check was blocking them even though they are not manually-added moves, preventing users from validating returns on sale orders with `block_additional_quantity` enabled.

closes #119948