### PR TITLE
[IMP] stock_ux: improve margin in stock.picking.type kanban view

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.11.0",
+    "version": "19.0.1.12.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/views/stock_picking_type_views.xml
+++ b/stock_ux/views/stock_picking_type_views.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0"?>
 <odoo>
 
+    <record id="stock_picking_type_kanban" model="ir.ui.view">
+        <field name="name">stock.picking.type.kanban</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//t[@t-name='card']//a[@name='get_action_picking_tree_waiting']" position="attributes">
+                <attribute name="class">col-12 pe-0 text-truncate</attribute>
+            </xpath>
+            <xpath expr="//a[@name='get_action_picking_tree_late']" position="attributes">
+                <attribute name="class">col-12 pe-0 text-truncate</attribute>
+            </xpath>
+            <xpath expr="//a[@name='get_action_picking_tree_backorder']" position="attributes">
+                <attribute name="class">col-12 pe-0 text-truncate</attribute>
+            </xpath>
+            <xpath expr="//a[@name='get_action_picking_type_ready_moves']" position="attributes">
+                <attribute name="class">col-12 pe-0 text-truncate</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_picking_type_form" model="ir.ui.view">
         <field name="name">stock.picking.type.form</field>
         <field name="model">stock.picking.type</field>


### PR DESCRIPTION
## Summary

Port of #902 to 19.0.

Overrides the class on the overview links in `stock.picking.type` kanban card (`Waiting`, `Late`, `Back Orders`, `Operations`) to `col-12 pe-0 text-truncate`, fixing the margin display.