### PR TITLE
[FIX] stock_voucher_ux: number preprinted vouchers by real pages

### DIFF
--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -98,9 +98,18 @@ class ReportController(report.ReportController):
                     # If not PDF or can't process (like .doc), assign only 1 voucher
                     number_pages = 1
 
-                # See if there are vouchers already assigned. If not, then it assigns the vouchers
-                if not request.env["stock.picking"].browse(picking_id).voucher_ids and book_id:
-                    request.env["stock.picking"].browse(picking_id).assign_numbers(number_pages, book_id)
+                # See if there are vouchers already assigned. If not, assign them
+                # based on the real page count, then re-render so the numbers show.
+                picking = request.env["stock.picking"].browse(picking_id)
+                if not picking.voucher_ids and book_id:
+                    picking.assign_numbers(number_pages, book_id)
+                    picking.env.flush_all()
+                    # Re-render: the first PDF had no numbers yet; this second
+                    # render includes the just-assigned voucher numbers.
+                    try:
+                        response = super().report_download(data, context=context, token=token, **kwargs)
+                    except Exception:
+                        pass
 
         elif "report_deliveryslip" in url:
             # Fallback: if numbers weren't pre-assigned (e.g. printed outside
@@ -136,6 +145,12 @@ class ReportController(report.ReportController):
                             number_pages = 1
 
                         picking.assign_numbers(number_pages, book_id)
+                        picking.env.flush_all()
+                        # Re-render so the assigned numbers appear on the first PDF.
+                        try:
+                            response = super().report_download(data, context=context, token=token, **kwargs)
+                        except Exception:
+                            pass
 
                 elif book_id and picking_id:
                     if not picking.voucher_ids and book_id:

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -39,10 +39,14 @@ class StockPicking(models.Model):
         if not self.book_id and self.picking_type_code != "incoming":
             raise UserError("Primero debe seleccionar un talonario")
         if self.autoprinted == False:
-            if self.book_id and not self.voucher_ids:
-                self.assign_numbers(self.get_estimated_number_of_pages(), self.book_id)
+            # Talonario preimpreso: la cantidad de remitos debe coincidir con las
+            # páginas REALES del reporte. No pre-asignamos por la estimación
+            # ``lines_per_voucher`` (subnumera: p. ej. asigna 3 cuando el remito
+            # tiene 5 páginas). Imprimimos con ``assign=True`` para que el
+            # controller cuente las páginas renderizadas, asigne los números y
+            # re-renderice el PDF ya con los números puestos.
             self.printed = True
-            return self.do_print_voucher()
+            return self.with_context(assign=True).do_print_voucher()
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
                 raise UserError(
@@ -53,6 +57,18 @@ class StockPicking(models.Model):
                 )
             self.assign_numbers(1, self.book_id)
             return self.do_print_voucher()
+
+    def _action_done(self):
+        # Los talonarios preimpresos (``autoprinted=False``) se numeran al
+        # IMPRIMIR según las páginas reales del reporte, no en la validación por
+        # la estimación ``lines_per_voucher``. Evitamos que la base los
+        # pre-asigne acá; los autoimpresos siguen numerándose como antes.
+        res = super(StockPicking, self.with_context(do_not_assign_numbers=True))._action_done()
+        if self._context.get("do_not_assign_numbers"):
+            return res
+        for picking in self.filtered(lambda p: p.book_required and p.book_id and p.book_id.autoprinted):
+            picking.assign_numbers(picking.get_estimated_number_of_pages(), picking.book_id)
+        return res
 
     def clean_voucher_data(self):
         return super(StockPicking, self).clean_voucher_data()

--- a/stock_voucher_ux/tests/__init__.py
+++ b/stock_voucher_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_remito_preimpreso

--- a/stock_voucher_ux/tests/test_remito_preimpreso.py
+++ b/stock_voucher_ux/tests/test_remito_preimpreso.py
@@ -1,0 +1,104 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestRemitoPreimpresoNumbering(TransactionCase):
+    """Numeración de remitos según el tipo de talonario.
+
+    Preimpreso (``autoprinted=False``): NO se numera en la validación por la
+    estimación ``lines_per_voucher`` (subnumera). La cantidad se determina al
+    imprimir, según las páginas reales del reporte (controller).
+
+    Autoimpreso (``autoprinted=True``): conserva el comportamiento previo
+    (asigna en la validación).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sequence = cls.env["ir.sequence"].create(
+            {
+                "name": "Test stock voucher",
+                "code": "stock.voucher",
+                "prefix": "0001-",
+                "padding": 8,
+                "implementation": "no_gap",
+            }
+        )
+        cls.book_pre = cls.env["stock.book"].create(
+            {
+                "name": "Preimpreso test",
+                "sequence_id": cls.sequence.id,
+                "lines_per_voucher": 25,
+                "autoprinted": False,
+            }
+        )
+        cls.book_auto = cls.env["stock.book"].create(
+            {
+                "name": "Autoimpreso test",
+                "sequence_id": cls.sequence.id,
+                "lines_per_voucher": 0,
+                "autoprinted": True,
+            }
+        )
+        # Consumible no almacenable: la validación no requiere stock disponible.
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Producto remito test",
+                "type": "consu",
+            }
+        )
+        cls.src = cls.env.ref("stock.stock_location_stock")
+        cls.dest = cls.env.ref("stock.stock_location_customers")
+
+    def _make_done_picking(self, book):
+        picking_type = self.env.ref("stock.picking_type_out")
+        picking_type.write({"book_required": True, "book_id": book.id, "voucher_required": False})
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.src.id,
+                "location_dest_id": self.dest.id,
+                "book_id": book.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1.0,
+                            "product_uom": self.product.uom_id.id,
+                            "location_id": self.src.id,
+                            "location_dest_id": self.dest.id,
+                        },
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.with_context(skip_sms=True).button_validate()
+        return picking
+
+    def test_preprinted_not_preassigned_on_validation(self):
+        picking = self._make_done_picking(self.book_pre)
+        self.assertEqual(picking.state, "done")
+        self.assertFalse(
+            picking.voucher_ids,
+            "Un talonario preimpreso no debe pre-numerarse por estimación en _action_done; "
+            "la numeración se hace al imprimir según páginas reales.",
+        )
+
+    def test_autoprinted_assigned_on_validation(self):
+        picking = self._make_done_picking(self.book_auto)
+        self.assertEqual(picking.state, "done")
+        self.assertEqual(
+            len(picking.voucher_ids),
+            1,
+            "Un talonario autoimpreso debe asignar un único remito en la validación.",
+        )


### PR DESCRIPTION
## What

For preprinted voucher books (`autoprinted=False`), the amount of remito numbers
assigned to a picking must match the **real number of pages** of the rendered
report. Since #941 the count was taken from the `lines_per_voucher` estimate
(`ceil(move_line_ids / lines_per_voucher)`) and pre-assigned **before** printing,
which under-counts whenever the report paginates to more pages than the estimate
predicts (e.g. 3 numbers assigned for a 5-page remito).

#941 switched to the estimate so the numbers would show on the first PDF; this PR
keeps that goal but recovers the correct count.

## How

- `do_print_and_assign`: for `autoprinted=False`, drop the estimate pre-assign and
  print with `assign=True`, so the controller counts the **real rendered pages**
  (`_count_pages_with_products`).
- `controllers/main.py`: after assigning by the real page count, `flush_all()` and
  **re-render** so the voucher numbers appear on the first delivered PDF. Applied to
  both the aeroo and the qweb (`report_deliveryslip`) branches — this restores the
  re-render removed in #941, now also for the aeroo path.
- `_action_done`: preprinted books are no longer pre-assigned by the estimate (they
  are numbered at print time by real pages); autoprinted books keep their previous
  behaviour.

## Test plan

- Added `stock_voucher_ux/tests/test_remito_preimpreso.py`:
  - preprinted book → no vouchers assigned on validation (deferred to print);
  - autoprinted book → exactly one voucher assigned on validation.
- Runbot / manual: print a preprinted remito that spans N pages → N voucher numbers
  assigned and all visible on the first PDF.

Follow-up of #941.
