### PR TITLE
[ADD] stock_repair_ux: button to create repair from receipt

### DIFF
--- a/stock_repair_ux/README.rst
+++ b/stock_repair_ux/README.rst
@@ -1,0 +1,78 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============
+Stock Repair UX
+===============
+
+Since Odoo 19, creating a repair order from a receipt is a native feature, but
+it is only reachable from the "Actions" (gear) menu of the transfer, so it goes
+unnoticed.
+
+This module surfaces that same native action as a visible **Crear Reparación**
+button on the header of incoming transfers (receipts and returns), without
+having to enable any setting on the operation type.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Just install this module.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. No configuration needed.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Open an incoming transfer (a receipt or a return).
+#. Click the **Crear Reparación** button on the header to create a repair order
+   prefilled with the transfer's partner and product.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/stock/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/stock_repair_ux/__manifest__.py
+++ b/stock_repair_ux/__manifest__.py
@@ -1,0 +1,37 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Repair UX",
+    "version": "19.0.1.0.0",
+    "category": "Warehouse Management",
+    "summary": "Show a visible button to create a repair from a receipt",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "repair",
+    ],
+    "data": [
+        "views/stock_picking_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/stock_repair_ux/i18n/es.po
+++ b/stock_repair_ux/i18n/es.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_repair_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-01 17:03+0000\n"
+"PO-Revision-Date: 2026-07-01 17:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
+"0) ? 1 : 2);\n"
+
+#. module: stock_repair_ux
+#: model_terms:ir.ui.view,arch_db:stock_repair_ux.view_picking_form
+msgid "Create Repair"
+msgstr "Crear Reparación"

--- a/stock_repair_ux/i18n/stock_repair_ux.pot
+++ b/stock_repair_ux/i18n/stock_repair_ux.pot
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_repair_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-01 17:03+0000\n"
+"PO-Revision-Date: 2026-07-01 17:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_repair_ux
+#: model_terms:ir.ui.view,arch_db:stock_repair_ux.view_picking_form
+msgid "Create Repair"
+msgstr ""

--- a/stock_repair_ux/views/stock_picking_views.xml
+++ b/stock_repair_ux/views/stock_picking_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.repair.button</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <!-- Expose the native repair "Acciones" item as a visible button on receipts.
+                 Placed last in the header so "Validate" stays the leftmost/primary action,
+                 as creating a repair is an occasional action on a return. -->
+            <xpath expr="//header" position="inside">
+                <button name="action_repair_return" type="object"
+                        string="Create Repair"
+                        invisible="picking_type_code != 'incoming' or state == 'cancel'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## What

Since Odoo 19, creating a repair order from a transfer is native (`action_repair_return` on `stock.picking`, exposed as the `Create Repair` server action). But it is only reachable from the **Actions** (gear) menu, so users coming from v18 — where it was a boolean on the operation type — don't find it.

This module adds a visible **Crear Reparación** button on the header of incoming transfers (receipts and returns) that triggers the same native `action_repair_return`. No setting on the operation type is required.

## How

- New module `stock_repair_ux` depending on `repair`.
- A single view inheriting `stock.view_picking_form` adds a header button calling `action_repair_return`, visible when `picking_type_code == 'incoming'` and `state != 'cancel'`.
- No Python — it reuses the core action as-is.

## Test plan

1. Install `stock_repair_ux`.
2. Open an incoming transfer (a receipt or a return).
3. The **Crear Reparación** button shows in the header; clicking it opens a new repair order prefilled with the transfer's partner and product.
4. On deliveries / internal transfers the button is hidden.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/121770