### PR TITLE
[FIX] stock_request_ux: group order moves into one picking

### DIFF
--- a/stock_request_ux/models/stock_request.py
+++ b/stock_request_ux/models/stock_request.py
@@ -40,6 +40,17 @@ class StockRequest(models.Model):
             )
             rec.check_done()
 
+    def _prepare_procurement_values(self, reference_ids=False):
+        values = super()._prepare_procurement_values(reference_ids=reference_ids)
+        # Si la línea pertenece a una orden y no se cargaron referencias a mano,
+        # inyectamos una referencia por defecto por orden para que todas las
+        # líneas se agrupen en un único picking (ver
+        # StockRequestOrder._get_default_stock_reference). En Odoo 19 el
+        # agrupamiento se basa en reference_ids, no en el procurement group.
+        if self.order_id and not values.get("reference_ids"):
+            values["reference_ids"] = self.order_id._get_default_stock_reference()
+        return values
+
     def _action_launch_procurement_rule(self):
         """TODO we could create an option or check if procurement_jit
         is installed

--- a/stock_request_ux/models/stock_request_order.py
+++ b/stock_request_ux/models/stock_request_order.py
@@ -3,7 +3,7 @@
 # directory
 ##############################################################################
 
-from odoo import api, fields, models
+from odoo import Command, api, fields, models
 
 
 class StockRequestOrder(models.Model):
@@ -13,9 +13,47 @@ class StockRequestOrder(models.Model):
     warehouse_id = fields.Many2one(
         change_default=True,
     )
+    # Referencia generada automáticamente para agrupar los movimientos de la
+    # orden en un único picking (análogo a ``sale.order.stock_reference_ids``).
+    # Es independiente de ``reference_ids`` (las referencias que carga el
+    # usuario a mano) y sirve como anclaje idempotente por orden.
+    stock_reference_ids = fields.Many2many(
+        "stock.reference",
+        "stock_request_order_default_reference_rel",
+        "order_id",
+        "reference_id",
+        string="Default Grouping Reference",
+        copy=False,
+    )
 
     @api.onchange("route_id")
     def onchange_route_id(self):
         for line in self.stock_request_ids:
             if self.route_id.id in line.route_ids.ids:
                 line.route_id = self.route_id.id
+
+    def _prepare_reference_vals(self):
+        self.ensure_one()
+        return {"name": self.name}
+
+    def _get_default_stock_reference(self):
+        """Referencia por defecto para agrupar los movimientos de la orden.
+
+        En Odoo 19 el agrupamiento de movimientos en un mismo picking dejó de
+        basarse en el procurement group y pasa a basarse en ``reference_ids``
+        (modelo ``stock.reference``). Un movimiento sin referencia nunca se
+        fusiona con un picking existente (ver
+        ``stock.move._search_picking_for_assignation``), por lo que sin este
+        default cada línea de la orden termina generando su propio picking.
+
+        Generamos (una sola vez) una referencia por orden y la guardamos en
+        ``stock_reference_ids`` para que todas sus líneas se agrupen en un único
+        picking sin tener que cargar la referencia a mano —replicando el
+        comportamiento documentado en el campo ``reference_ids``— y sin depender
+        de una búsqueda por nombre (el nombre de la orden es único solo por
+        compañía).
+        """
+        self.ensure_one()
+        if not self.stock_reference_ids:
+            self.stock_reference_ids = [Command.create(self._prepare_reference_vals())]
+        return self.stock_reference_ids


### PR DESCRIPTION
## Problem

When confirming a stock request order **without loading any reference**, the module generated a **separate picking per line** instead of grouping all the order lines into a single picking.

## Root cause

In Odoo 19 the picking assignment key changed from the procurement group to `reference_ids` (the new core `stock.reference` model). A move without a reference is never merged into an existing picking:

```python
# odoo/addons/stock/models/stock_move.py
def _search_picking_for_assignation(self):
    if not self.reference_ids:
        return self.env['stock.picking']  # never reuses an existing picking
```

Since `stock_request` launches the procurement line by line and does not set a default reference, each line ends up in its own picking. Core documents (sale/purchase/mrp) all create a `stock.reference` named after the document to group their moves; `stock_request` did not.

## Fix

Set a default per-order `stock.reference` (derived from the order name) in the procurement values when no reference was loaded manually, so all the lines of an order are grouped into a single picking — matching the documented behaviour of the `reference_ids` field ("if none are given, the moves generated by procurement rules will be grouped into one big picking").

- `StockRequestOrder._get_default_stock_reference()`: get-or-create the reference for the order.
- `StockRequest._prepare_procurement_values()`: inject it when the line belongs to an order and no reference is set.

Loading references manually keeps working exactly as before.