### PR TITLE
[FIX] stock_voucher: propagate super() result on cancel backorder

### DIFF
--- a/stock_voucher/wizards/stock_backorder_confirmation.py
+++ b/stock_voucher/wizards/stock_backorder_confirmation.py
@@ -34,7 +34,7 @@ class StockBackorderConfirmation(models.TransientModel):
             return res
 
     def process_cancel_backorder(self):
-        super().process_cancel_backorder()
+        res = super().process_cancel_backorder()
         pickings = (
             self.env["stock.picking"]
             .browse(
@@ -47,4 +47,7 @@ class StockBackorderConfirmation(models.TransientModel):
             .filtered("book_required")
         )
         if pickings:
+            if isinstance(res, dict):
+                return res, pickings.do_print_voucher()
             return pickings.do_print_voucher()
+        return res


### PR DESCRIPTION
## Problema

Al validar un despacho con **reserva parcial** y elegir **"Sin orden parcial"** (No Backorder), el picking no se completaba: quedaba en estado **"Listo"** en lugar de pasar a "Hecho". En cambio, "Crear orden parcial" funcionaba bien.

Ref: ticket helpdesk **121768** (cliente entrenuts, 18.0).

## Causa

`stock.backorder.confirmation.process_cancel_backorder` (override de `stock_voucher`) **descartaba el valor de retorno de `super()`**. El método estándar de Odoo devuelve ahí la acción que finaliza la validación del picking (`pickings.button_validate()`). Al no propagarla, y con `book_required=False`, el método terminaba devolviendo `None` → el flujo se cortaba y el picking no llegaba a "Hecho".

El método hermano `process()` **sí** captura y devuelve `res`; esta era una asimetría entre ambos.

## Solución

Capturar el retorno de `super().process_cancel_backorder()` y propagarlo, replicando el patrón ya existente en `process()` (combinándolo con la acción de impresión de voucher cuando hay pickings `book_required`).

## Test

Base de prueba con `stock_voucher_ux`: entrega con reserva parcial → Validar → "Sin orden parcial".
- **Antes:** queda en "Listo".
- **Después:** valida correctamente (pasa a "Hecho").