### PR TITLE
[ADD] stock_ux: auto-activate multi-warehouse group for branch warehouses

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -40,6 +40,7 @@ Stock UX
 #. Add a "All transfers" view form in Menu: Operations
 #. Add a restriction to edit operation type for users with the "Restrict editing Operation Type in Pickings" check.
 #. Add number of packages on pickings
+#. Auto-activate the "Manage Multiple Warehouses" permission when a company has branches (child companies) with warehouses: warehouses are counted across the whole company tree instead of per single company, so one warehouse per branch also enables it. Warehouses of archived companies are not counted, and archiving or restoring a branch re-checks the permission.
 
 Installation
 ============

--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -16,3 +16,5 @@ from . import stock_scrap
 from . import stock_location
 from . import stock_forecasted
 from . import stock_quant
+from . import res_company
+from . import stock_warehouse

--- a/stock_ux/models/res_company.py
+++ b/stock_ux/models/res_company.py
@@ -1,0 +1,19 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    def write(self, vals):
+        """Archivar o reactivar una sucursal cambia los almacenes que quedan
+        en juego, así que hay que revisar el permiso "Gestionar varios
+        almacenes": el nativo solo lo revisa al tocar un almacén, y archivar
+        una compañía no archiva los suyos."""
+        res = super().write(vals)
+        if "active" in vals:
+            self.env["stock.warehouse"]._check_multiwarehouse_group()
+        return res

--- a/stock_ux/models/stock_warehouse.py
+++ b/stock_ux/models/stock_warehouse.py
@@ -1,0 +1,54 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from collections import defaultdict
+
+from odoo import models
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    def _multiwarehouse_count_by_root_company(self):
+        """Almacenes activos de compañías activas, contados por árbol de
+        compañías (la raíz suma los de sus sucursales). Para una compañía sin
+        sucursales ``root_id`` es ella misma."""
+        count_by_root = defaultdict(int)
+        groups = (
+            self.env["stock.warehouse"]
+            .sudo()
+            ._read_group(
+                [("active", "=", True), ("company_id.active", "=", True)], ["company_id"], aggregates=["__count"]
+            )
+        )
+        for company, count in groups:
+            count_by_root[company.root_id] += count
+        return count_by_root
+
+    def _check_multiwarehouse_group(self):
+        """Activa o desactiva "Gestionar varios almacenes" contando los
+        almacenes por árbol de compañías.
+
+        El nativo los agrupa por ``company_id``, así que un almacén por sucursal
+        deja el conteo en 1 por compañía y el permiso nunca se activa. Además
+        cuenta los almacenes de compañías archivadas, con lo cual archivar una
+        sucursal no baja el conteo.
+
+        Mantener la lógica de activación / desactivación sincronizada con
+        ``stock.warehouse._check_multiwarehouse_group`` en cada upgrade.
+        """
+        max_count = max(self._multiwarehouse_count_by_root_company().values(), default=0)
+        group_user = self.env.ref("base.group_user")
+        group_multi_warehouses = self.env.ref("stock.group_stock_multi_warehouses")
+        if max_count <= 1:
+            if group_multi_warehouses in group_user.implied_ids:
+                group_user.write({"implied_ids": [(3, group_multi_warehouses.id)]})
+                group_multi_warehouses.write({"user_ids": [(3, user.id) for user in group_user.all_user_ids]})
+            return
+        if group_multi_warehouses in group_user.implied_ids:
+            return
+        group_multi_locations = self.env.ref("stock.group_stock_multi_locations")
+        if group_multi_locations not in group_user.implied_ids:
+            self.env["res.config.settings"].create({"group_stock_multi_locations": True}).execute()
+        group_user.write({"implied_ids": [(4, group_multi_warehouses.id), (4, group_multi_locations.id)]})

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_mto_warehouse_propagation
+from . import test_multiwarehouse_group

--- a/stock_ux/tests/test_multiwarehouse_group.py
+++ b/stock_ux/tests/test_multiwarehouse_group.py
@@ -1,0 +1,116 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("stock_ux_multiwarehouse")
+class TestMultiwarehouseGroupBranch(TransactionCase):
+    """El permiso "Gestionar varios almacenes" debe seguir a los almacenes del
+    árbol de compañías: se activa cuando una compañía tiene sucursales con
+    almacenes (aunque cada una tenga uno solo) y se desactiva cuando esos
+    almacenes o sus compañías dejan de estar activos. En modo test crear una
+    ``res.company`` le crea su almacén (ver ``stock/models/res_company.py``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Warehouse = cls.env["stock.warehouse"]
+        cls.group_user = cls.env.ref("base.group_user")
+        cls.group_multi_wh = cls.env.ref("stock.group_stock_multi_warehouses")
+        cls.parent_company = cls.env["res.company"].create({"name": "UX Madre"})
+
+    def _create_branch(self, name="UX Sucursal"):
+        return self.env["res.company"].create({"name": name, "parent_id": self.parent_company.id})
+
+    def _warehouses_of(self, company):
+        return self.Warehouse.with_context(active_test=False).search([("company_id", "=", company.id)])
+
+    def _native_max_count(self):
+        """Conteo del método nativo: máximo de almacenes activos de UNA compañía."""
+        groups = self.Warehouse.sudo()._read_group([("active", "=", True)], ["company_id"], aggregates=["__count"])
+        return max((count for _company, count in groups), default=0)
+
+    def test_warehouses_are_counted_by_company_tree(self):
+        branch = self._create_branch()
+        self.assertEqual(branch.root_id, self.parent_company)
+
+        native = self.Warehouse.sudo()._read_group(
+            [("active", "=", True), ("company_id", "in", (self.parent_company + branch).ids)],
+            ["company_id"],
+            aggregates=["__count"],
+        )
+        self.assertEqual(
+            sorted(count for _company, count in native),
+            [1, 1],
+            "Cada compañía del árbol tiene un solo almacén, por eso el conteo nativo no alcanza.",
+        )
+        self.assertEqual(
+            self.Warehouse._multiwarehouse_count_by_root_company()[self.parent_company],
+            2,
+            "Madre y sucursal deben contarse juntas bajo la compañía raíz.",
+        )
+
+    def test_branch_warehouse_activates_multi_wh_group(self):
+        # Partir del permiso desactivado: si ya viene implicado el test no
+        # probaría nada.
+        self.group_user.write({"implied_ids": [(3, self.group_multi_wh.id)]})
+        self.assertNotIn(self.group_multi_wh, self.group_user.implied_ids)
+        self.assertEqual(
+            self._native_max_count(),
+            1,
+            "Ninguna compañía sola llega a dos almacenes; si no, el nativo activaría el "
+            "permiso por su cuenta y el test dejaría de discriminar.",
+        )
+
+        # Crear la sucursal crea su almacén y con eso corre _check_multiwarehouse_group.
+        self._create_branch()
+
+        self.assertIn(
+            self.group_multi_wh,
+            self.group_user.implied_ids,
+            "Con una madre y una sucursal, cada una con su almacén, el permiso "
+            "'Gestionar varios almacenes' debe activarse automáticamente.",
+        )
+
+    def test_archived_branch_deactivates_group(self):
+        branch = self._create_branch()
+        self.assertIn(self.group_multi_wh, self.group_user.implied_ids)
+
+        # Archivar la compañía no archiva su almacén: el conteo tiene que
+        # ignorarlo igual y revisar el permiso.
+        branch.write({"active": False})
+
+        self.assertTrue(all(self._warehouses_of(branch).mapped("active")))
+        self.assertEqual(self.Warehouse._multiwarehouse_count_by_root_company()[self.parent_company], 1)
+        self.assertNotIn(
+            self.group_multi_wh,
+            self.group_user.implied_ids,
+            "Archivada la sucursal queda un solo almacén en juego: el permiso debe desactivarse.",
+        )
+
+    def test_unarchived_branch_activates_group_again(self):
+        branch = self._create_branch()
+        branch.write({"active": False})
+        self.assertNotIn(self.group_multi_wh, self.group_user.implied_ids)
+
+        branch.write({"active": True})
+
+        self.assertIn(self.group_multi_wh, self.group_user.implied_ids)
+
+    def test_archived_branch_warehouse_deactivates_group(self):
+        branch = self._create_branch()
+        self.assertIn(self.group_multi_wh, self.group_user.implied_ids)
+
+        self._warehouses_of(branch).write({"active": False})
+
+        self.assertNotIn(self.group_multi_wh, self.group_user.implied_ids)
+
+    def test_single_warehouse_per_company_deactivates_group(self):
+        """Sin sucursales, con un solo almacén por compañía, el permiso se
+        desactiva igual que en el nativo (sin regresión para el caso simple)."""
+        self.group_user.write({"implied_ids": [(4, self.group_multi_wh.id)]})
+        self.assertEqual(self._native_max_count(), 1)
+
+        self.Warehouse._check_multiwarehouse_group()
+
+        self.assertNotIn(self.group_multi_wh, self.group_user.implied_ids)


### PR DESCRIPTION
## What

Make the standard *Manage Multiple Warehouses* group
(`stock.group_stock_multi_warehouses`) follow the warehouses of the whole
**company tree**: activate it when a company has **branches** (child
companies) that own warehouses — even with a single warehouse each — and turn
it off again when those warehouses, or their branches, are archived.

## Why

Native `stock.warehouse._check_multiwarehouse_group()` counts active
warehouses grouped by `company_id`, and only activates the group when a
single company has more than one warehouse. A branch is a child
`res.company` with its own `company_id`, so a setup with one warehouse per
branch leaves the per-company count at 1 and the multi-warehouse UI is never
enabled. The behaviour is the same on 18.0; this generalizes the counting.

The other half is the way back. Archiving a company does **not** archive its
warehouses, and the native check only runs on warehouse `create` / archive /
`unlink`, so archiving a branch left the count untouched and the permission
on — with no way to turn it off from the interface: Settings refuses to
untick *Storage Locations* while multi-warehouse is implied
(`res.config.settings.set_values`), and multi-warehouse itself is not a
user-facing checkbox.

## How

Override the method in `stock_ux`:

- `_multiwarehouse_count_by_root_company()` counts active warehouses **of
  active companies**, aggregated by `company_id.root_id` (the top of the
  company tree), so a parent company and its branches count together.
- `_check_multiwarehouse_group()` activates / deactivates on that count. For
  a company **without** branches `root_id` is the company itself, so nothing
  changes for non-branch setups.
- `res.company.write()` re-runs the check when a company is archived or
  restored — the events that change which warehouses are in play and that the
  native method never sees. (The hierarchy itself cannot change afterwards:
  `res.company.write` refuses `parent_id`.)

## Test plan

`stock_ux/tests/test_multiwarehouse_group.py`:
- `test_warehouses_are_counted_by_company_tree`: parent + branch, one
  warehouse each, count 1 per `company_id` natively but 2 under the root.
- `test_branch_warehouse_activates_multi_wh_group`: starting with the group
  not implied, creating a branch with a warehouse activates it.
- `test_archived_branch_deactivates_group`: archiving the branch (its
  warehouse stays active) drops the count and removes the group.
- `test_unarchived_branch_activates_group_again`: and restoring it puts the
  group back.
- `test_archived_branch_warehouse_deactivates_group`: same going through the
  warehouse instead of the company.
- `test_single_warehouse_per_company_deactivates_group`: no regression for
  setups without branches.

`0 failed, 0 error(s) of 8 tests` locally with `-u stock_ux --test-enable
--test-tags /stock_ux`. Each piece was checked in isolation: dropping the
`res.company` hook, or the active-company filter in the count, makes
`test_archived_branch_deactivates_group` and
`test_unarchived_branch_activates_group_again` fail.

Task: https://www.adhoc.inc/odoo/my-tasks/69369
