### PR TITLE
[FIX] stock_voucher_ux: read aeroo copies from the printed remito report

### DIFF
--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -77,10 +77,8 @@ class ReportController(report.ReportController):
             assign = context_dict.get("assign")
             book_id = request.env["stock.picking"].browse(picking_id).book_id
             if assign and book_id and picking_id:
-                copies_result = request.env["ir.actions.report"].search_read(
-                    [("report_name", "ilike", "remito")], ["copies"], limit=1
-                )
-                copies = copies_result[0]["copies"] if copies_result else None
+                # Copias del reporte que se imprime, resuelto por su report_name en la URL.
+                copies = request.env["ir.actions.report"]._get_voucher_copies_from_url(url)
                 # Check if response is PDF, if not (like .doc), assign 1 voucher
                 try:
                     pdf_response = response.response[0]

--- a/stock_voucher_ux/models/__init__.py
+++ b/stock_voucher_ux/models/__init__.py
@@ -2,5 +2,6 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from . import ir_actions_report
 from . import stock_book
 from . import stock_picking

--- a/stock_voucher_ux/models/ir_actions_report.py
+++ b/stock_voucher_ux/models/ir_actions_report.py
@@ -1,0 +1,19 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _get_voucher_copies_from_url(self, url):
+        """Copias (campo aeroo ``copies``) del reporte que se imprime,
+        resuelto por su ``report_name`` en la URL."""
+        marker = "/report/aeroo/"
+        if marker not in url:
+            return None
+        report_name = url.split(marker)[1].split("?")[0].split("/")[0]
+        report = self.search([("report_name", "=", report_name)], limit=1)
+        return report.copies if report else None


### PR DESCRIPTION
### Problem

When numbering pre-printed vouchers, the controller divides the rendered PDF page count by the report's aeroo `copies` field, so the physical duplicate/triplicate copies aren't counted as extra vouchers.

It read `copies` with `[("report_name", "ilike", "remito")], limit=1`, which matches **any** report whose `report_name` contains "remito".

On databases with more than one aeroo remito report configured with different `copies` (e.g. a generic remito with `copies=2` and a "carta porte" with `copies=1`), that unordered lookup returns the `copies` of the wrong report. The printed remito renders 2 pages (copies=2) but the controller reads copies=1, so `total_pages = pages / 1 = 2` and it assigns **2 voucher numbers instead of 1**, shifting the sequence permanently.

### Fix

Resolve `copies` from the report actually being printed, matching its `report_name` extracted from the aeroo download URL (`/report/aeroo/<report_name>`). Extracted into `ir.actions.report._get_voucher_copies_from_url`.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/122167