### PR TITLE
[FIX] stock_voucher_ux: print voucher on validation when auto-print is set

### DIFF
--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -58,15 +58,40 @@ class StockPicking(models.Model):
             self.assign_numbers(1, self.book_id)
             return self.do_print_voucher()
 
+    def button_validate(self):
+        # Imprime el remito al validar sólo si el tipo de operación lo pide
+        # (``auto_print_delivery_slip``). Autoimpreso: ya numerado en
+        # ``_action_done``, sólo imprime. Preimpreso: numera al imprimir por
+        # páginas reales (mismo camino que "Imprimir Remito").
+        res = super().button_validate()
+        if (
+            len(self) == 1
+            and self.state == "done"
+            and self.book_required
+            and self.book_id
+            and self.picking_type_id.auto_print_delivery_slip
+        ):
+            if self.autoprinted:
+                return self.do_print_voucher()
+            return self.do_print_and_assign()
+        return res
+
     def _action_done(self):
         # Los talonarios preimpresos (``autoprinted=False``) se numeran al
         # IMPRIMIR según las páginas reales del reporte, no en la validación por
-        # la estimación ``lines_per_voucher``. Evitamos que la base los
-        # pre-asigne acá; los autoimpresos siguen numerándose como antes.
+        # la estimación ``lines_per_voucher``. Los autoimpresos se numeran acá al
+        # validar, pero sólo si el tipo de operación pide imprimir el remito al
+        # validar (``auto_print_delivery_slip``) — el remito reemplaza al recibo
+        # de entrega nativo. Sin ese flag el número se asigna al IMPRIMIR a mano.
         res = super(StockPicking, self.with_context(do_not_assign_numbers=True))._action_done()
         if self._context.get("do_not_assign_numbers"):
             return res
-        for picking in self.filtered(lambda p: p.book_required and p.book_id and p.book_id.autoprinted):
+        for picking in self.filtered(
+            lambda p: p.book_required
+            and p.book_id
+            and p.book_id.autoprinted
+            and p.picking_type_id.auto_print_delivery_slip
+        ):
             picking.assign_numbers(picking.get_estimated_number_of_pages(), picking.book_id)
         return res
 

--- a/stock_voucher_ux/tests/test_remito_preimpreso.py
+++ b/stock_voucher_ux/tests/test_remito_preimpreso.py
@@ -12,8 +12,10 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
     estimación ``lines_per_voucher`` (subnumera). La cantidad se determina al
     imprimir, según las páginas reales del reporte (controller).
 
-    Autoimpreso (``autoprinted=True``): conserva el comportamiento previo
-    (asigna en la validación).
+    Autoimpreso (``autoprinted=True``): se numera en la validación sólo si el
+    tipo de operación pide imprimir el remito al validar
+    (``auto_print_delivery_slip``) — el remito reemplaza al recibo de entrega
+    nativo. Sin ese flag no se numera al validar (se asigna al imprimir a mano).
     """
 
     @classmethod
@@ -54,9 +56,16 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
         cls.src = cls.env.ref("stock.stock_location_stock")
         cls.dest = cls.env.ref("stock.stock_location_customers")
 
-    def _make_done_picking(self, book):
+    def _make_done_picking(self, book, auto_print=False):
         picking_type = self.env.ref("stock.picking_type_out")
-        picking_type.write({"book_required": True, "book_id": book.id, "voucher_required": False})
+        picking_type.write(
+            {
+                "book_required": True,
+                "book_id": book.id,
+                "voucher_required": False,
+                "auto_print_delivery_slip": auto_print,
+            }
+        )
         picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": picking_type.id,
@@ -94,11 +103,24 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
             "la numeración se hace al imprimir según páginas reales.",
         )
 
-    def test_autoprinted_assigned_on_validation(self):
-        picking = self._make_done_picking(self.book_auto)
+    def test_autoprinted_assigned_on_validation_with_flag(self):
+        # Con auto_print_delivery_slip el remito reemplaza al recibo de entrega
+        # y el autoimpreso se numera al validar.
+        picking = self._make_done_picking(self.book_auto, auto_print=True)
         self.assertEqual(picking.state, "done")
         self.assertEqual(
             len(picking.voucher_ids),
             1,
-            "Un talonario autoimpreso debe asignar un único remito en la validación.",
+            "Un talonario autoimpreso debe asignar un único remito en la validación "
+            "cuando el tipo de operación tiene auto_print_delivery_slip.",
+        )
+
+    def test_autoprinted_not_assigned_without_flag(self):
+        # Sin el flag, validar no numera: el número se asigna al imprimir a mano.
+        picking = self._make_done_picking(self.book_auto, auto_print=False)
+        self.assertEqual(picking.state, "done")
+        self.assertFalse(
+            picking.voucher_ids,
+            "Sin auto_print_delivery_slip, un talonario autoimpreso no debe numerarse "
+            "en la validación; el número se asigna al imprimir.",
         )

--- a/stock_voucher_ux/wizards/__init__.py
+++ b/stock_voucher_ux/wizards/__init__.py
@@ -2,6 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
-from . import controllers
-from . import wizards
+from . import stock_backorder_confirmation

--- a/stock_voucher_ux/wizards/stock_backorder_confirmation.py
+++ b/stock_voucher_ux/wizards/stock_backorder_confirmation.py
@@ -1,0 +1,24 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+from odoo.addons.stock_voucher.wizards.stock_backorder_confirmation import (
+    StockBackorderConfirmation as VoucherBackorderConfirmation,
+)
+
+
+class StockBackorderConfirmation(models.TransientModel):
+    _inherit = "stock.backorder.confirmation"
+
+    def process(self):
+        # En Odoo 18 el core re-ejecuta ``button_validate`` sobre los pickings al
+        # confirmar el backorder, y ese camino ya imprime el remito (respetando
+        # ``auto_print_delivery_slip`` y numerando el preimpreso con assign=True).
+        # Saltamos el override de ``stock_voucher``, que reimprimía con
+        # ``do_print_voucher`` sin assign (dejaba el preimpreso sin numerar) y
+        # devolvía una tupla que el cliente no ejecuta.
+        return super(VoucherBackorderConfirmation, self).process()
+
+    def process_cancel_backorder(self):
+        return super(VoucherBackorderConfirmation, self).process_cancel_backorder()


### PR DESCRIPTION
## What

Print the delivery voucher automatically on validation, gated by the operation type's native `auto_print_delivery_slip` flag — so it only happens when explicitly enabled, not on every validation.

## Why

In Odoo 18 `button_validate` returns `True` (not `None`) when validating without a wizard, so the `if res is None` branch in `stock_voucher.button_validate` stopped running after the migration: the voucher number is still assigned but the voucher is no longer printed on validation. Restoring it unconditionally would print on every book picking; instead we tie it to `auto_print_delivery_slip` so each operation type opts in.

## How

Override `button_validate` in `stock_voucher_ux`. On a completed validation (`state == "done"`) of a single picking whose operation type has `auto_print_delivery_slip` and a book:
- autoprinted book: already numbered in `_action_done`, only print (`do_print_voucher`);
- pre-printed book: numbered on print by real page count (`do_print_and_assign`, `assign=True`), same path as the "Print Voucher" button.

Without the flag, or on a wizard (backorder), the `super()` result is returned untouched — no auto-print, no other behavior changes.

## Test plan

Operation type with `auto_print_delivery_slip` on:
- pre-printed book: validating returns the voucher print action and numbers by real page count;
- autoprinted book: validating prints without duplicating the number.

Operation type with the flag off: validating only completes the transfer, no print.

Task: https://www.adhoc.inc/odoo/project.task/70863
