### PR TITLE
[ADD] stock_voucher_ux_iot: assign preprinted voucher numbers on IoT print

### DIFF
--- a/stock_voucher_ux_iot/README.rst
+++ b/stock_voucher_ux_iot/README.rst
@@ -1,0 +1,77 @@
+======================
+Stock Voucher UX - IoT
+======================
+
+Assign preprinted voucher (remito) numbers when the report is printed through an
+IoT printer.
+
+Características
+===============
+
+- Cuando el remito preimpreso se imprime a través de una impresora IoT, asigna
+  automáticamente los números de remito al picking, igual que ocurre al
+  descargar el PDF desde el navegador.
+- La asignación se basa en la cantidad real de páginas con productos del reporte
+  renderizado (dividida por la cantidad de copias del reporte), no en una
+  estimación.
+- Solo aplica a talonarios preimpresos (``autoprinted = False``); los talonarios
+  autoimpresos siguen numerándose en la validación.
+- Es idempotente: si el picking ya tiene números asignados, un reintento de
+  impresión no consume números de secuencia adicionales.
+
+Detalles Técnicos
+=================
+
+- Modelos nuevos: ninguno.
+- Modelos heredados:
+
+  - ``ir.actions.report``: sobrescribe ``render_and_send`` (método provisto por
+    el módulo ``iot``) para asignar los números de remito antes de delegar en
+    ``super()``, de modo que el documento que se renderiza y se envía a la
+    impresora ya los incluye. Métodos auxiliares:
+    ``_is_preprinted_voucher_report`` (detecta el reporte aeroo de remito sobre
+    ``stock.picking``), ``_assign_preprinted_voucher_numbers``,
+    ``_count_voucher_pages`` y ``_count_pages_with_products``.
+
+- Vistas incluidas: ninguna.
+- Datos / seguridad: ninguno.
+
+Uso
+===
+
+1. Configurar en el reporte aeroo del remito preimpreso uno o más dispositivos
+   IoT de tipo impresora (campo ``IoT Devices`` de ``ir.actions.report``).
+2. Asegurarse de que el picking tenga asignado un talonario preimpreso
+   (``stock.book`` con ``autoprinted = False``).
+3. Imprimir el remito. Al enviarse a la impresora IoT, los números de remito se
+   asignan automáticamente al picking y aparecen en el documento impreso.
+
+Arquitectura
+============
+
+Módulo puente entre ``stock_voucher_ux`` e ``iot``.
+
+En el flujo de descarga por navegador, ``stock_voucher_ux`` asigna los números
+de remito en su override del controller ``/report/download``. El camino de
+impresión por IoT nunca pasa por ese controller: el handler del cliente
+(``iot/static/src/iot_report_action.js``) llama a
+``ir.actions.report.render_and_send``, que renderiza el documento del lado del
+servidor y lo envía directo a la impresora, cortocircuitando la acción. Este
+módulo cubre ese hueco enganchándose en ``render_and_send``, de forma que la
+asignación de números ocurre independientemente del canal de impresión.
+
+Dependencias
+============
+
+- ``stock_voucher_ux``
+- ``iot``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/stock_voucher_ux_iot/__init__.py
+++ b/stock_voucher_ux_iot/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/stock_voucher_ux_iot/__manifest__.py
+++ b/stock_voucher_ux_iot/__manifest__.py
@@ -1,0 +1,39 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Voucher UX - IoT",
+    "version": "18.0.1.0.0",
+    "category": "Warehouse Management",
+    "sequence": 14,
+    "summary": "Assign preprinted voucher numbers when the remito is printed " "through an IoT printer",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "stock_voucher_ux",
+        "iot",
+    ],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/stock_voucher_ux_iot/models/__init__.py
+++ b/stock_voucher_ux_iot/models/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import ir_actions_report

--- a/stock_voucher_ux_iot/models/ir_actions_report.py
+++ b/stock_voucher_ux_iot/models/ir_actions_report.py
@@ -1,0 +1,118 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import io
+import logging
+import re
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from PyPDF2 import PdfFileReader
+except ImportError:  # pragma: no cover
+    _logger.debug("PyPDF2 could not be imported; voucher page counting will fall back to 1.")
+    PdfFileReader = None
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def render_and_send(self, devices, res_ids, data=None, print_id=0, websocket=True):
+        """Assign the preprinted voucher numbers when the remito is printed
+        through an IoT printer.
+
+        On the regular (browser download) flow the numbers are assigned by
+        ``stock_voucher_ux``'s ``/report/download`` controller. The IoT path
+        never reaches that controller: the client handler
+        (``iot/static/src/iot_report_action.js``) calls this method and
+        short-circuits the action, so the document is rendered server-side and
+        streamed straight to the printer. We assign the numbers *before*
+        delegating to ``super()`` so the render it performs already carries
+        them, mirroring the download flow.
+        """
+        if self._is_preprinted_voucher_report():
+            self._assign_preprinted_voucher_numbers(res_ids, data=data)
+        return super().render_and_send(devices, res_ids, data=data, print_id=print_id, websocket=websocket)
+
+    def _is_preprinted_voucher_report(self):
+        """The remito preimpreso is an aeroo report on ``stock.picking`` whose
+        ``report_name`` contains ``remito`` (same guard the download controller
+        uses)."""
+        self.ensure_one()
+        return self.model == "stock.picking" and self.report_type == "aeroo" and "remito" in (self.report_name or "")
+
+    def _assign_preprinted_voucher_numbers(self, res_ids, data=None):
+        """Assign voucher numbers to every preprinted picking in ``res_ids``
+        that still has none, based on the real number of rendered pages."""
+        self.ensure_one()
+        for picking in self.env["stock.picking"].browse(res_ids):
+            book = picking.book_id
+            # Only preprinted books (autoprinted=False) are numbered at print
+            # time; autoprinted books are numbered on validation. Skip pickings
+            # that already have numbers to keep this idempotent (a retry of the
+            # print must not burn extra sequence numbers).
+            if not book or book.autoprinted or picking.voucher_ids:
+                continue
+            number_of_pages = self._count_voucher_pages(picking, data=data)
+            picking.assign_numbers(number_of_pages, book)
+            picking.env.flush_all()
+
+    def _count_voucher_pages(self, picking, data=None):
+        """Render the report once (numbers not assigned yet) and count the real
+        number of pages that contain products, capped by the page count without
+        copies. Falls back to a single voucher when the output cannot be parsed
+        as a multi-page PDF (e.g. ``.doc`` output)."""
+        self.ensure_one()
+        if PdfFileReader is None:
+            return 1
+        try:
+            content = self._render(self.report_name, picking.ids, data=data)[0]
+            reader = PdfFileReader(io.BytesIO(content))
+            pages_with_products = self._count_pages_with_products(reader, picking)
+            copies = self.copies or 0
+            if copies:
+                total_pages = int(len(reader.pages) / copies)
+                return max(1, min(pages_with_products, total_pages))
+            return max(1, pages_with_products)
+        except Exception:  # noqa: BLE001 - any render/parse issue -> single voucher
+            return 1
+
+    def _count_pages_with_products(self, pdf_reader, picking):
+        """Count the pages that actually contain products by matching product
+        identifiers (internal reference / barcode) in the page text, in a
+        language independent way. Mirrors the logic used by the download
+        controller in ``stock_voucher_ux``."""
+        move_lines = picking.move_line_ids or picking.move_ids
+
+        product_identifiers = set()
+        for line in move_lines:
+            product = line.product_id
+            if not product:
+                continue
+            if product.default_code:
+                product_identifiers.add(product.default_code.lower().strip())
+            if product.barcode:
+                product_identifiers.add(product.barcode.lower().strip())
+
+        pages_with_products = 0
+        for page_num in range(len(pdf_reader.pages)):
+            try:
+                text = pdf_reader.pages[page_num].extract_text()
+                if not text:
+                    continue
+                text_lower = text.lower()
+                if product_identifiers and any(pid in text_lower for pid in product_identifiers):
+                    has_products = True
+                else:
+                    # Fallback: generic numeric pattern (language independent).
+                    has_products = bool(re.search(r"\b\d+[.,]\d+\b", text_lower))
+                if has_products:
+                    pages_with_products += 1
+            except Exception:  # noqa: BLE001 - if text can't be extracted assume it has products
+                pages_with_products += 1
+
+        # There is always at least one page with products.
+        return max(1, pages_with_products)

--- a/stock_voucher_ux_iot/tests/__init__.py
+++ b/stock_voucher_ux_iot/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_iot_voucher

--- a/stock_voucher_ux_iot/tests/test_iot_voucher.py
+++ b/stock_voucher_ux_iot/tests/test_iot_voucher.py
@@ -1,0 +1,174 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+class _FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class _FakeReader:
+    """Duck-typed stand-in for ``PyPDF2.PdfFileReader`` so the page-counting
+    logic can be tested without rendering a real (LibreOffice) aeroo PDF."""
+
+    def __init__(self, texts):
+        self.pages = [_FakePage(t) for t in texts]
+
+
+@tagged("post_install", "-at_install")
+class TestStockVoucherUxIot(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Voucher Product",
+                "type": "consu",
+                "default_code": "TESTPROD1",
+            }
+        )
+
+        cls.sequence = cls.env["ir.sequence"].create(
+            {
+                "name": "Test Remito Sequence",
+                "code": "stock.voucher",
+                "padding": 8,
+                "number_next": 1,
+                "implementation": "no_gap",
+            }
+        )
+        cls.book = cls.env["stock.book"].create(
+            {
+                "name": "Test Preprinted Book",
+                "sequence_id": cls.sequence.id,
+                "lines_per_voucher": 0,
+                "autoprinted": False,
+                "company_id": cls.company.id,
+            }
+        )
+
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [("code", "=", "outgoing"), ("company_id", "=", cls.company.id)],
+            limit=1,
+        )
+        cls.src_location = cls.picking_type_out.default_location_src_id or cls.env.ref("stock.stock_location_stock")
+        cls.dest_location = cls.picking_type_out.default_location_dest_id or cls.env.ref(
+            "stock.stock_location_customers"
+        )
+
+        # The aeroo remito report NGRSA prints through the IoT box. We only need
+        # the record to exist; its rendering is mocked in the tests.
+        cls.report = cls.env["ir.actions.report"].create(
+            {
+                "name": "Test Remito Preimpreso",
+                "report_name": "remito_test",
+                "report_type": "aeroo",
+                "model": "stock.picking",
+                "copies": 3,
+            }
+        )
+        cls.report_cls = type(cls.report)
+
+    def _new_picking(self, book=None):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_out.id,
+                "location_id": self.src_location.id,
+                "location_dest_id": self.dest_location.id,
+                "book_id": (book or self.book).id,
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+                "product_uom": self.product.uom_id.id,
+                "picking_id": picking.id,
+                "location_id": self.src_location.id,
+                "location_dest_id": self.dest_location.id,
+            }
+        )
+        return picking
+
+    def test_iot_assigns_voucher_numbers(self):
+        """Printing the preprinted remito through IoT assigns as many voucher
+        numbers as real pages the report has."""
+        picking = self._new_picking()
+        self.assertFalse(picking.voucher_ids)
+        with patch.object(self.report_cls, "_render", return_value=(b"%PDF-1.4 fake", "pdf")), patch.object(
+            self.report_cls, "_count_voucher_pages", return_value=3
+        ):
+            self.report.render_and_send([], picking.ids)
+        self.assertEqual(len(picking.voucher_ids), 3, "IoT print must assign one voucher per rendered page")
+
+    def test_iot_is_idempotent_when_vouchers_exist(self):
+        """A re-print through IoT must not burn extra sequence numbers."""
+        picking = self._new_picking()
+        picking.assign_numbers(2, self.book)
+        self.assertEqual(len(picking.voucher_ids), 2)
+        with patch.object(self.report_cls, "_render", return_value=(b"%PDF-1.4 fake", "pdf")), patch.object(
+            self.report_cls, "_count_voucher_pages", return_value=5
+        ):
+            self.report.render_and_send([], picking.ids)
+        self.assertEqual(len(picking.voucher_ids), 2, "Already numbered pickings must be left untouched")
+
+    def test_iot_skips_autoprinted_book(self):
+        """Autoprinted books are numbered on validation, not at print time."""
+        autoprinted_book = self.env["stock.book"].create(
+            {
+                "name": "Test Autoprinted Book",
+                "sequence_id": self.sequence.id,
+                "lines_per_voucher": 0,
+                "autoprinted": True,
+                "company_id": self.company.id,
+            }
+        )
+        picking = self._new_picking(book=autoprinted_book)
+        with patch.object(self.report_cls, "_render", return_value=(b"%PDF-1.4 fake", "pdf")), patch.object(
+            self.report_cls, "_count_voucher_pages", return_value=3
+        ):
+            self.report.render_and_send([], picking.ids)
+        self.assertFalse(picking.voucher_ids, "Autoprinted books must not be numbered on the IoT print path")
+
+    def test_iot_skips_non_remito_report(self):
+        """A non-remito report must not trigger voucher assignment."""
+        other_report = self.env["ir.actions.report"].create(
+            {
+                "name": "Test Other Aeroo",
+                "report_name": "some_other_report",
+                "report_type": "aeroo",
+                "model": "stock.picking",
+                "copies": 1,
+            }
+        )
+        picking = self._new_picking()
+        with patch.object(self.report_cls, "_render", return_value=(b"%PDF-1.4 fake", "pdf")), patch.object(
+            self.report_cls, "_count_voucher_pages", return_value=3
+        ):
+            other_report.render_and_send([], picking.ids)
+        self.assertFalse(picking.voucher_ids, "Only the remito report must assign voucher numbers")
+
+    def test_count_pages_with_products(self):
+        """Pages are counted as containing products when the product code (or a
+        generic decimal, as fallback) shows up in the page text."""
+        picking = self._new_picking()
+        reader = _FakeReader(
+            [
+                "Cliente XYZ\nProducto TESTPROD1 x 1",  # product code -> counts
+                "Página de continuación sin líneas",  # nothing -> not counted
+                "12,50 total",  # decimal fallback -> counts
+                "",  # empty -> not counted
+            ]
+        )
+        self.assertEqual(self.report._count_pages_with_products(reader, picking), 2)


### PR DESCRIPTION
## What

New bridge module `stock_voucher_ux_iot` (`depends: stock_voucher_ux, iot`, `auto_install=True`).

When a preprinted stock voucher (aeroo *remito*) is printed through an IoT printer, the voucher numbers were never assigned to the picking. Printing the same report by downloading the PDF from the browser assigned them correctly.

## Why

The voucher-number assignment lives in `stock_voucher_ux`'s `/report/download` controller. The IoT print path never reaches that controller: the client handler (`iot/static/src/iot_report_action.js`) calls `ir.actions.report.render_and_send`, which renders the document server-side and streams it straight to the printer, short-circuiting the report action. As a result, on the IoT path `assign_numbers` never ran.

## How

The module overrides `render_and_send`. For the preprinted remito report (`model == stock.picking`, `report_type == aeroo`, `"remito" in report_name` — same guard the download controller uses) it assigns the voucher numbers **before** delegating to `super()`, based on the real rendered page count (divided by the report copies), so the document that is rendered and sent to the printer already carries them, mirroring the download flow.

- Scoped to preprinted books (`autoprinted == False`); autoprinted books keep being numbered on validation.
- Idempotent: a re-print does not consume extra sequence numbers.
- Trigger-agnostic: it re-derives the decision from the picking + book (the `assign` context flag does not travel through the IoT RPC).
- No double assignment: `render_and_send` only runs on the IoT path, disjoint from the download controller; and the module is not installed for deployments without `iot`.

## Test plan

`stock_voucher_ux_iot/tests/test_iot_voucher.py` (5 tests, green):

- assigns one voucher per rendered page on the IoT path;
- is idempotent when vouchers already exist;
- skips autoprinted books;
- skips non-remito reports;
- counts pages with products by product identifier, with a decimal fallback.

Aeroo rendering is mocked because it requires LibreOffice (not available in CI).

Internal ticket: https://www.adhoc.inc/odoo/action-5389/122297
