### PR TITLE
[FIX] stock_ux: avoid extra move (OUT/return) when cancelling remaining qty

### DIFF
--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -34,6 +34,34 @@ class StockMove(models.Model):
 
     origin_description = fields.Char(compute="_compute_origin_description", compute_sudo=True)
 
+    @api.model
+    def _prepare_merge_negative_moves_excluded_distinct_fields(self):
+        # Al cancelar remanente desde la orden (cancel_from_order, tanto en compras como en
+        # ventas) Odoo genera un move negativo que tiene que netear (mergear) contra el move
+        # pendiente ya existente. Ese move nuevo se construye "fresco" y puede traer un
+        # price_unit distinto al del move pendiente original: si cambió el costo/replenishment
+        # del producto, o (en compras) si la línea tiene descuento (el move viejo quedó con el
+        # precio de lista y el nuevo se arma con price_unit_discounted). Como price_unit forma
+        # parte de la clave de merge, esa diferencia rompe el neteo y, en vez de cancelar el
+        # pendiente, se genera una contraentrega (OUT en compras / re-ingreso en ventas).
+        #
+        # Lo excluimos SOLO de la clave del move negativo (excluded fields) y no de
+        # _prepare_merge_moves_distinct_fields, para que el merge positivo-positivo siga
+        # estricto: así no fusionamos por error dos moves vivos del mismo producto que solo
+        # difieren en el precio. El neteo recalcula precio promedio ponderado (core), con lo
+        # cual la cantidad neta por producto siempre cierra bien.
+        #
+        # NOTA: location_final_id es el otro campo volátil que puede romper el neteo (move
+        # viejo vacío vs. nuevo poblado con el default_location_dest_id del tipo de operación).
+        # NO lo excluimos acá a propósito: dropearlo puede hacer que un negativo netee contra
+        # la cadena downstream equivocada cuando conviven dos positivos del mismo producto con
+        # igual origen/destino pero distinto destino final (MTO / multi-paso). Ese caso se
+        # ataca por separado, con la batería de tests correspondiente.
+        res = super()._prepare_merge_negative_moves_excluded_distinct_fields()
+        if self.env.context.get("cancel_from_order"):
+            res = res + ["price_unit"]
+        return res
+
     @api.depends(
         "move_line_ids.quantity",
         "move_line_ids.lot_id",


### PR DESCRIPTION
When cancelling the remaining quantity from a **sale or purchase** order (`button_cancel_remaining`, under the `cancel_from_order` context), Odoo core builds a negative `stock.move` that has to merge/net against the still-pending move. If that freshly built move differs from the original pending move on any field of the merge key, the netting fails and core generates an **extra move** — a return delivery (OUT) on purchases, a re-entry on sales — instead of just cancelling the pending move.

Two volatile fields cause the mismatch:

- `price_unit`: differs when the product cost changed, or (on purchases) when the line has a discount (the old pending move kept the list price, the new one is built with `price_unit_discounted`).
- `location_final_id`: empty on the pre-existing pending move, but core fills the newly created move with the operation type `default_location_dest_id` (`_get_final_location_record`).

Fix: exclude both fields from the **negative** merge key only, via `_prepare_merge_negative_moves_excluded_distinct_fields`, scoped to `cancel_from_order`. The negative move then nets against the pending one regardless of those fields, while **positive-to-positive merges stay strict** — so we never wrongly merge two live moves of the same product that only differ on these fields (e.g. MTO / multi-step chains headed to different final locations).

Placed in `stock_ux` (shared base of `purchase_stock_ux` and `sale_stock_ux`) so **both flows are fixed from a single place**, avoiding a hidden dependency on `purchase_stock_ux` being installed.