### PR TITLE
[FIX] stock_ux, stock_batch_picking_ux: drop removed partner mobile field

### DIFF
--- a/stock_batch_picking_ux/reports/picking_templates.xml
+++ b/stock_batch_picking_ux/reports/picking_templates.xml
@@ -67,29 +67,15 @@
 ,
 <t class="oe_inline" t-esc="batch.partner_id.country_id.name"/>
 ^FS ^FO50,545^FDTel: ^FS
-<t t-if="batch.partner_id and (batch.partner_id.phone != False or batch.partner_id.mobile != False)">
-<t t-if="batch.partner_id.phone">
+<t t-if="batch.partner_id and batch.partner_id.phone">
 ^FO100,545^FD
 <t t-esc="batch.partner_id.phone"/>
 ^FS
 </t>
-<t t-else="">
-^FO100,545^FD
-<t t-esc="batch.partner_id.mobile"/>
-^FS
-</t>
-</t>
-<t t-if="batch.partner_id.parent_id and (batch.partner_id.parent_id.phone != False or batch.partner_id.parent_id.mobile != False) and (batch.partner_id.phone == False and batch.partner_id.mobile == False)">
-<t t-if="batch.partner_id.parent_id.phone">
+<t t-elif="batch.partner_id.parent_id and batch.partner_id.parent_id.phone">
 ^FO100,545^FD
 <t t-esc="batch.partner_id.parent_id.phone"/>
 ^FS
-</t>
-<t t-else="">
-^FO100,545^FD
-<t t-esc="batch.partner_id.parent_id.mobile"/>
-^FS
-</t>
 </t>
 <t t-else="">
 ^FS
@@ -190,21 +176,11 @@ Fecha
 ,
                             <t class="oe_inline" t-esc="batch.partner_id.country_id.name"/>
                             <div style="font-weight: normal;">Tel:
-                                <t t-if="batch.partner_id and (batch.partner_id.phone != False or batch.partner_id.mobile != False)">
-                                    <t t-if="batch.partner_id.phone">
-                                        <t t-esc="batch.partner_id.phone"/>
-                                    </t>
-                                    <t t-else="">
-                                        <t t-esc="batch.partner_id.mobile"/>
-                                    </t>
+                                <t t-if="batch.partner_id and batch.partner_id.phone">
+                                    <t t-esc="batch.partner_id.phone"/>
                                 </t>
-                                <t t-if="batch.partner_id.parent_id and (batch.partner_id.parent_id.phone != False or batch.partner_id.parent_id.mobile != False) and (batch.partner_id.phone == False and batch.partner_id.mobile == False)">
-                                    <t t-if="batch.partner_id.parent_id.phone">
-                                        <t t-esc="batch.partner_id.parent_id.phone"/>
-                                    </t>
-                                    <t t-else="">
-                                        <t t-esc="batch.partner_id.parent_id.mobile"/>
-                                    </t>
+                                <t t-elif="batch.partner_id.parent_id and batch.partner_id.parent_id.phone">
+                                    <t t-esc="batch.partner_id.parent_id.phone"/>
                                 </t>
                                 <t t-else="">
                                 </t>

--- a/stock_ux/report/picking_templates.xml
+++ b/stock_ux/report/picking_templates.xml
@@ -52,14 +52,8 @@
 <t t-if="picking.partner_id and picking.partner_id.phone">
 ^FO100,545^FD<t t-esc="picking.partner_id.phone"/>^FS
 </t>
-<t t-elif="picking.partner_id and picking.partner_id.mobile">
-^FO100,545^FD<t t-esc="picking.partner_id.mobile"/>^FS
-</t>
 <t t-elif="picking.partner_id.parent_id and picking.partner_id.parent_id.phone">
 ^FO100,545^FD<t t-esc="picking.partner_id.parent_id.phone"/>^FS
-</t>
-<t t-elif="picking.partner_id.parent_id and picking.partner_id.parent_id.mobile">
-^FO100,545^FD<t t-esc="picking.partner_id.parent_id.mobile"/>^FS
 </t>
 <!-- Fin destino -->
 <t t-if="picking._fields.get('carrier_id') and picking.carrier_id">


### PR DESCRIPTION
## Problem

Printing the shipping label ZPL crashes on 19.0:

```
QWebError: Error while rendering the template:
    AttributeError: 'res.partner' object has no attribute 'mobile'
    Template: stock_ux.custom_label_transfer_template_view_zpl
    Element: <t t-elif="picking.partner_id and picking.partner_id.mobile"/>
```

`res.partner.mobile` no longer exists in 19.0 — it was merged into `phone`. Both ZPL templates still referenced it:

- `stock_ux.custom_label_transfer_template_view_zpl`
- `stock_batch_picking_ux.custom_label_batch_transfer_template_view_zpl` (and its PDF variant, which had the same reference)

It went unnoticed because the `mobile` branch is a `t-elif` / `t-else` over the `phone` one: it is only evaluated when the partner has **no phone set**. With a phone loaded the label renders fine, which is why this survived the migration.

`stock_ux`'s PDF variant was already fixed in 9007ba20 (#908); the ZPL of the same module was missed, and `stock_batch_picking_ux` was not covered at all.

## Approach

Drop the `mobile` branches and keep the intended fallback chain: partner phone → parent partner phone. Same shape 9007ba20 applied to the PDF.

In `stock_batch_picking_ux` the two blocks were a `t-if` plus a second `t-if` whose condition manually re-checked that the first one had not matched (`... and batch.partner_id.phone == False and ...`). Now that `mobile` is gone those collapse into a plain `t-if` / `t-elif` / `t-else` chain, which is what the manual guard was emulating — same rendering, less to read.

No behaviour change for partners that have a phone.

## Test plan

On a 19.0 build, for both `stock_ux` (picking) and `stock_batch_picking_ux` (batch):

1. Partner **without** phone → print the label (ZPL and PDF): renders with an empty `Tel:`, no traceback. This is what fails today.
2. Partner **without** phone but whose parent company **has** one → the parent's phone is printed.
3. Partner **with** phone → unchanged output.

Merge needs `bump` — the diff touches data XML that is persisted in `ir.ui.view`, so the modules must be updated on deploy.
