### PR TITLE
[FIX] stock_voucher: keep voucher numbering when carrier confirmation fails

### DIFF
--- a/stock_voucher/__manifest__.py
+++ b/stock_voucher/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Voucher",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.7.1",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_voucher/models/stock_picking.py
+++ b/stock_voucher/models/stock_picking.py
@@ -87,8 +87,39 @@ class StockPicking(models.Model):
         self.message_post(body=_("Números de remitos asignados: %s") % (self.vouchers))
         self.write({"book_id": book.id})
 
-        # Send confirmation email with voucher numbers already assigned
-        self.with_context(from_assign_numbers=True)._send_confirmation_email()
+        # Send confirmation email with voucher numbers already assigned.
+        # The confirmation path may reach the carrier integration (send_to_shipper),
+        # which can raise a UserError unrelated to the voucher itself (e.g. a
+        # base_on_rule carrier without a matching price rule). The voucher is a
+        # fiscal document already numbered above, so it must not be rolled back by
+        # such an error: we isolate the call in a savepoint and, on failure,
+        # degrade the error to a chatter note plus a warning activity for the user.
+        try:
+            with self.env.cr.savepoint():
+                self.with_context(from_assign_numbers=True)._send_confirmation_email()
+        except UserError as error:
+            carrier = "carrier_id" in self._fields and self.carrier_id
+            if carrier:
+                hint = _(
+                    'The delivery method "%(carrier)s" could not compute a shipping '
+                    "cost for this transfer, usually because it has no price rule "
+                    "matching the order. Add an applicable price rule to that "
+                    "delivery method (e.g. a catch-all rule), or change/remove the "
+                    "delivery method on the transfer."
+                ) % {"carrier": carrier.name}
+            else:
+                hint = _("Please review the delivery method configured on the transfer.")
+            message = _(
+                "The voucher was numbered correctly, but the confirmation email / "
+                "carrier notification could not be sent.\n\n%(hint)s\n\nDetails: %(error)s"
+            ) % {"hint": hint, "error": error}
+            self.message_post(body=message)
+            self.activity_schedule(
+                "mail.mail_activity_data_warning",
+                summary=_("Voucher confirmation could not be sent"),
+                note=message,
+                user_id=self.user_id.id or self.env.user.id,
+            )
 
     def clean_voucher_data(self):
         self.voucher_ids.unlink()


### PR DESCRIPTION
### Problem

Printing a delivery voucher (`do_print_and_assign` → `assign_numbers`) sends the
confirmation email, which through `_send_confirmation_email` can reach the carrier
integration (`send_to_shipper`). A `base_on_rule` carrier without a matching price
rule raises `UserError("Not available for current order")`.

Because `assign_numbers` runs in a single transaction, that error rolled back the
**whole** operation — including the voucher numbers already assigned above. The
voucher is a fiscal document, so the picking ended up validated but **unnumbered**,
and the user only saw a cryptic RPC error.

### Fix

Isolate the confirmation email / carrier call in a savepoint. On `UserError` the
voucher numbering is preserved and the error is degraded to a chatter note plus a
warning activity for the responsible user — the same resilience pattern Odoo core
already applies for batch pickings in `stock_delivery`.

The message is actionable: it names the delivery method that failed and explains
what to configure (add a matching price rule, or change/remove the delivery method
on the transfer), instead of surfacing the raw core error.

The numbering no longer depends on the carrier being correctly configured; a
carrier misconfiguration is surfaced as an actionable warning instead of blocking
the fiscal document.

Ticket 123970.