### PR TITLE
[FIX] stock_ux: use column_invisible for statically hidden list columns

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.13.0",
+    "version": "19.0.1.14.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/views/stock_move_line_views.xml
+++ b/stock_ux/views/stock_move_line_views.xml
@@ -71,15 +71,15 @@
                 <attribute name="readonly">1</attribute>
             </field>
             <field name="date" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">True</attribute>
             </field>
             <field name="state" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">True</attribute>
             </field>
             <field name="product_id" position="after">
                 <field name="package_id" column_invisible="True"/>
                 <field name="result_package_id" column_invisible="True"/>
-                <field name="quantity" invisible="1"/>
+                <field name="quantity" column_invisible="True"/>
                 <field name="picking_id" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="product_uom_id" position="move"/>


### PR DESCRIPTION
## What

In list views (Odoo 17+), a static `invisible="1"` no longer hides the column: the header stays visible and only the cells are blanked. `column_invisible` is required to hide the whole column.

This converts the statically-hidden columns in the `stock.move.line` list view (`stock_ux.view_move_line_tree`) — `date`, `state` and `quantity` — from `invisible="1"` to `column_invisible="True"`.

## Why

These columns are meant to be fully hidden, but today they render an empty header in the operations list. Core `stock` already uses `column_invisible` for the same purpose in its list views.

## Test plan

- Open the detailed operations list on `stock.move.line` (e.g. from a picking).
- The `date`, `state` and `quantity` columns no longer show up as empty-header columns.
- Row-level conditional fields (e.g. `lot_id`) keep their per-row visibility unchanged.

Ref: Adhoc task #59491.
