### PR TITLE
[FIX] stock_batch_picking_ux: assign vouchers only after batch validation

### DIFF
--- a/stock_batch_picking_ux/models/stock_batch_picking.py
+++ b/stock_batch_picking_ux/models/stock_batch_picking.py
@@ -123,7 +123,6 @@ class StockPickingBatch(models.Model):
         }
 
     def action_done(self):
-        # agregamos los numeros de remito
         for rec in self:
             # al agregar la restriccion de que al menos una tenga que tener
             # cantidad entonces nunca se manda el force_qty al picking
@@ -148,8 +147,19 @@ class StockPickingBatch(models.Model):
             if rec.number_of_packages:
                 rec.picking_ids.write({"number_of_packages": rec.number_of_packages})
 
+        # los remitos se numeran después de validar y sólo para los traslados
+        # que quedaron en "done" y todavía sin remito
+        res = super(StockPickingBatch, self.with_context(do_not_assign_numbers=True)).action_done()
+
+        batch_voucher_installed = "stock_batch_picking_voucher" in self.env["ir.module.module"].search(
+            [("name", "=", "stock_batch_picking_voucher"), ("state", "=", "installed")]
+        ).mapped("name")
+
+        for rec in self:
             if rec.picking_type_code == "incoming" and rec.voucher_number:
                 for picking in rec.picking_ids:
+                    if picking.state != "done" or picking.voucher_ids:
+                        continue
                     # agregamos esto para que no se asigne a los pickings
                     # que no se van a recibir ya que todavia no se limpiaron
                     # y ademas, por lo de arriba, no se fuerza la cantidad
@@ -162,21 +172,19 @@ class StockPickingBatch(models.Model):
                             "name": rec.voucher_number,
                         }
                     )
-            else:
-                batch_voucher_installed = "stock_batch_picking_voucher" in self.env["ir.module.module"].search(
-                    [("name", "=", "stock_batch_picking_voucher"), ("state", "=", "installed")]
-                ).mapped("name")
-                if not batch_voucher_installed:
-                    for picking in rec.picking_ids:
-                        if not picking.picking_type_id.auto_print_delivery_slip:
-                            continue
-                        book = picking.book_id or picking.picking_type_id.book_id
-                        if not book:
-                            continue
-                        if all(operation.quantity == 0 for operation in picking.move_line_ids):
-                            continue
-                        picking.assign_numbers(picking.get_estimated_number_of_pages(), book)
-        return super(StockPickingBatch, self.with_context(do_not_assign_numbers=True)).action_done()
+            elif not batch_voucher_installed:
+                for picking in rec.picking_ids:
+                    if picking.state != "done" or picking.voucher_ids:
+                        continue
+                    if not picking.picking_type_id.auto_print_delivery_slip:
+                        continue
+                    book = picking.book_id or picking.picking_type_id.book_id
+                    if not book:
+                        continue
+                    if all(operation.quantity == 0 for operation in picking.move_line_ids):
+                        continue
+                    picking.assign_numbers(picking.get_estimated_number_of_pages(), book)
+        return res
 
     def action_view_stock_picking(self):
         """This function returns an action that display existing pickings of

--- a/stock_batch_picking_ux/tests/__init__.py
+++ b/stock_batch_picking_ux/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_batch_voucher_on_validate

--- a/stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py
+++ b/stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py
@@ -1,0 +1,92 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+
+
+class TestBatchVoucherOnValidate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.book = cls.env["stock.book"].create(
+            {
+                "name": "Talonario lote test",
+                "sequence_id": cls.env["ir.sequence"]
+                .create(
+                    {
+                        "name": "Test batch voucher",
+                        "code": "stock.voucher.batch.test",
+                        "prefix": "0001-",
+                        "padding": 8,
+                        "implementation": "no_gap",
+                    }
+                )
+                .id,
+                "lines_per_voucher": 0,
+            }
+        )
+        cls.product = cls.env["product.product"].create({"name": "Producto lote remito test", "type": "consu"})
+        cls.src = cls.env.ref("stock.stock_location_stock")
+        cls.dest = cls.env.ref("stock.stock_location_customers")
+        cls.picking_type = cls.env.ref("stock.picking_type_out")
+        cls.picking_type.write(
+            {
+                "book_required": True,
+                "book_id": cls.book.id,
+                "voucher_required": False,
+                "auto_print_delivery_slip": True,
+            }
+        )
+
+    def _new_batch(self):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.src.id,
+                "location_dest_id": self.dest.id,
+                "book_id": self.book.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1.0,
+                            "product_uom": self.product.uom_id.id,
+                            "location_id": self.src.id,
+                            "location_dest_id": self.dest.id,
+                        },
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+            move.picked = True
+        batch = self.env["stock.picking.batch"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "picking_ids": [(6, 0, picking.ids)],
+            }
+        )
+        batch.action_confirm()
+        return batch, picking
+
+    def test_voucher_only_for_validated_picking_and_once(self):
+        """Una validación abortada no numera y el reintento numera una sola vez."""
+        batch, picking = self._new_batch()
+        blocked_action = {"type": "ir.actions.act_window", "res_model": "stock.picking"}
+        with patch.object(type(picking), "button_validate", lambda self, *a, **k: blocked_action):
+            batch.action_done()
+        self.assertNotEqual(picking.state, "done")
+        self.assertFalse(picking.voucher_ids)
+
+        batch.action_done()
+        self.assertEqual(picking.state, "done")
+        self.assertEqual(len(picking.voucher_ids), 1)


### PR DESCRIPTION
## Problema

Al validar un lote (`stock.picking.batch`), los números de remito se asignaban al principio de `action_done`, dentro del `for rec in self`, **antes** de `super().action_done()` (que es donde corre la validación real de las transferencias).

Si la validación quedaba abortada **sin lanzar excepción** —por ejemplo una exception rule de `stock_exception` que devuelve el wizard "Outstanding exceptions to manage", o un backorder pendiente— los remitos ya creados quedaban pegados a transferencias que nunca llegaban a `done`, y como no hubo `raise` la transacción no se revertía. Además `assign_numbers` no tiene guarda de idempotencia, así que cada reintento de validación volvía a numerar (varios remitos por transferencia).

## Cambio

- Mover la asignación de números a **después** de `super().action_done()`.
- Asignar sólo a transferencias con `state == 'done'` y `not voucher_ids` (idempotencia), tanto en el branch de recepción con `voucher_number` como en el de salida con `auto_print_delivery_slip`.

## Test plan

Nuevo `stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py`:

- `test_success_numbers_validated_picking_once`: lote validado OK → 1 remito por transferencia.
- `test_blocked_validation_keeps_no_voucher_and_retry_numbers_once`: simula una validación abortada (`button_validate` devuelve una acción) → 0 remitos; reintento exitoso → exactamente 1 (sin acumular).

Verificado local (18.0): con el fix `0 failed of 2 tests`; revirtiendo sólo el cambio de código, el segundo test falla (`voucher(...) is not false`).

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/110928
