### PR TITLE
[FIX] stock_currency_valuation: use fields.Date instead of fields.date

### DIFF
--- a/stock_currency_valuation/models/product_template.py
+++ b/stock_currency_valuation/models/product_template.py
@@ -33,7 +33,7 @@ class productTemplate(models.Model):
                 from_amount=rec.standard_price_in_currency,
                 to_currency=product_currency,
                 company=company_id,
-                date=fields.date.today(),
+                date=fields.Date.today(),
             )
             # Then apply the rule on the converted amount
             replenishment_cost = replenishment_base_cost_on_currency


### PR DESCRIPTION
fields.date does not exist in odoo.fields, causing AttributeError in _compute_replenishment_cost when replenishment_cost_type is set to average_in_currency.