### PR TITLE
[FIX] stock_ux: extend super() when aggregating by origin description

### DIFF
--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -102,34 +102,6 @@ class StockMoveLine(models.Model):
         recs._check_manual_lines()
         return recs
 
-    def _get_aggregated_product_quantities(self, **kwargs):
-        aggregated_move_lines = super()._get_aggregated_product_quantities(**kwargs)
-        use_origin = (
-            self.env["ir.config_parameter"].sudo().get_param("stock_ux.delivery_slip_use_origin", "False") == "True"
-        )
-        if use_origin:
-            move_line_by_move = {}
-            for sml in self:
-                move = sml.move_id
-                if move and move.origin_description and sml.picking_id.origin:
-                    move_line_by_move.setdefault(
-                        move.id,
-                        {
-                            "description": move.origin_description,
-                            "product_id": sml.product_id.id,
-                        },
-                    )
-            used_moves = set()
-            for line_data in aggregated_move_lines.values():
-                for move_id, move_info in move_line_by_move.items():
-                    if move_info["product_id"] == line_data["product"].id and move_id not in used_moves:
-                        line_data["description"] = False
-                        line_data["reference"] = move_info["description"]
-                        used_moves.add(move_id)
-                        break
-
-        return aggregated_move_lines
-
     def _inverse_qty_done(self):
         """
         It uses the `from_inverse_qty_done` context key to indicate that the update originates from
@@ -140,48 +112,46 @@ class StockMoveLine(models.Model):
             line.picked = line.quantity > 0
 
     def _get_aggregated_properties(self, move_line=False, move=False):
+        """Con delivery_slip_use_origin mostramos la descripción de origen en vez de la de la
+        operación, pisando solo lo necesario sobre el dict del super."""
+        properties = super()._get_aggregated_properties(move_line=move_line, move=move)
         use_origin = (
             self.env["ir.config_parameter"].sudo().get_param("stock_ux.delivery_slip_use_origin", "False") == "True"
         )
         picking = move_line.picking_id if move_line else (move.picking_id if move else False)
-        if use_origin and picking and picking.origin:
-            move = move or move_line.move_id
-            uom = move.product_uom or move_line.product_uom_id
-            reference = move.product_id.display_name
-            origin_description = move.origin_description or reference
-            product = move.product_id
+        move = move or move_line.move_id
+        if not use_origin or not picking or not picking.origin or not move.origin_description:
+            return properties
 
-            add_product_name = (
-                self.env["ir.config_parameter"].sudo().get_param("stock_ux.delivery_slip_add_product_name", "False")
-                == "True"
-            )
+        product = move.product_id
+        reference = product.display_name
+        origin_description = move.origin_description
 
-            # Clean the origin_description by removing product name prefix
-            clean_description = origin_description
-            if origin_description != reference:
-                if origin_description.startswith(reference):
-                    clean_description = origin_description.removeprefix(reference).strip()
-                elif origin_description.startswith(product.name):
-                    clean_description = origin_description.removeprefix(product.name).strip()
+        add_product_name = (
+            self.env["ir.config_parameter"].sudo().get_param("stock_ux.delivery_slip_add_product_name", "False")
+            == "True"
+        )
 
-            if add_product_name and clean_description and clean_description != origin_description:
-                name = f"{product.name} {'-'} {clean_description}"
-            else:
-                name = clean_description if clean_description else origin_description
-            line_key = f"{product.id}_{name}_{uom.id}_{move.packaging_uom_id or ''}"
-            bom_line = getattr(move, "bom_line_id", False)
-            if bom_line and bom_line.bom_id:
-                bom = bom_line.bom_id
-                line_key += f"_{bom.id if bom else ''}"
-            else:
-                bom = False
-            return {
-                "line_key": line_key,
-                "name": name,
-                "product_uom": uom,
-                "move": move,
-                "packaging_uom_id": move.packaging_uom_id,
-                "bom": bom,
-            }
+        # Clean the origin_description by removing product name prefix
+        clean_description = origin_description
+        if origin_description != reference:
+            if origin_description.startswith(reference):
+                clean_description = origin_description.removeprefix(reference).strip()
+            elif origin_description.startswith(product.name):
+                clean_description = origin_description.removeprefix(product.name).strip()
+
+        if add_product_name and clean_description and clean_description != origin_description:
+            name = f"{product.name} - {clean_description}"
         else:
-            return super()._get_aggregated_properties(move_line=move_line, move=move)
+            name = clean_description or origin_description
+
+        properties.update(
+            {
+                "name": name,
+                # el origen ya viaja en el nombre, no lo repetimos abajo
+                "description": "",
+                # sumamos el origen a la clave del super para no fusionar orígenes distintos
+                "line_key": f"{properties['line_key']}_{name}",
+            }
+        )
+        return properties

--- a/stock_ux/views/stock_picking_views.xml
+++ b/stock_ux/views/stock_picking_views.xml
@@ -23,9 +23,6 @@
                 <field name="number_of_packages" invisible="picking_type_code == 'incoming'"/>
             </field>
 
-            <field name="description_picking" position="after">
-                <field name="reference" string="Descripción 2" optional="hide"/>
-            </field>
             <field name="product_uom" position="before">
                 <field name="lots_visible" column_invisible="True"/>
                 <field name="used_lots" groups="stock_ux.group_operation_used_lots" invisible="not lots_visible or state not in ['confirmed', 'assigned', 'waiting', 'partially_available', 'done']"/>


### PR DESCRIPTION
### Problem

With `stock_ux.delivery_slip_use_origin` enabled, `_get_aggregated_properties`
built its result dict from scratch instead of extending `super()`, so every key
the modules below it add was dropped. The MRO in our builds is:

```
stock_ux  ->  sale_stock_product_pack  ->  mrp  ->  stock
```

Three consequences, only the first one visible:

1. `mrp` reads `description` and crashes while rendering the kit sections of the
   delivery slip:

   ```
   File "odoo/addons/mrp/models/stock_move_line.py", line 97, in _get_aggregated_product_quantities
       description = aggregated_move_lines[aggregated_move_line]['description']
   KeyError: 'description'
   ```

2. `package` / `package_history` are lost. On transfers with nested packages the
   `Package` cell of each aggregated row prints empty (the column header and the
   package sections come from the picking, so those still render).

3. The `line_key` suffix `sale_stock_product_pack` adds is lost, so lines of the
   same product belonging to different packs are merged into a single row with
   the quantities summed.

The same shape already failed once: in 18.0 this override did carry
`description`, and it was dropped when the block was rewritten for the origin
description feature during the 19.0 migration.

### Fix

Extend the `super()` result and override only `name`, `description` and
`line_key`. The manual `line_key` / `bom` construction and the whole
`_get_aggregated_product_quantities` override become unnecessary — the
`reference` key the latter set is not read by any template in the build.

### Behaviour change

Two moves of the same product that share the origin description but have a
different `description_picking` used to be printed as a single aggregated line
and are now printed as two, because the core keeps `description_picking` in the
aggregation key. With this setting on, `description_picking` is not printed, so
those two rows carry the same visible text and differ only in quantity. This is
a deliberate trade-off, not a side effect: the alternative is to keep building
the key by hand, which is what dropped the keys above.

### Test plan

With `Use origin description on delivery slip` enabled in Inventory settings and
the transfer **validated** (the aggregated code path only runs on done
transfers — in `Ready` the report renders through another branch and the bug
does not reproduce):

1. Kit product (phantom BoM): printing the delivery slip raised
   `KeyError: 'description'`, now renders.
2. Nested packages: the `Package` cell of each row shows the inner package.
3. Product present in two different packs: one row per pack instead of a single
   merged row.
4. Regular transfer with an origin: the line name still shows the origin
   description.

Checked locally on v19 with `mrp` installed for 1 and 4. Cases 2 and 3 were
measured on a build with packages and `sale_stock_product_pack`.

---

### Also here: dropping the "Descripción 2" column

Second commit, unrelated to the crash but in the same view area.

That optional column showed `stock.move.name`, the second description field a
move used to carry besides `description_picking`. Odoo removed the field in
19.0 (*"not really relevant as we already have the reference field"*) and the
migration repointed the column to `reference`, a stored compute that returns
`picking_id.name` — so it now shows the transfer reference repeated on every
line instead of a description.

Nothing reads it: no report template in this repo, in `stock_batch_picking_ux`
/ `stock_delivery_zone`, or in OCA `stock-logistics-workflow`. It is hidden by
default, so removing it only affects users who had enabled it by hand, and
those were seeing wrong data. The meaningful counterpart, `origin_description`,
is already added as an optional column in the same position.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124422
