### PR TITLE
[FIX] stock_voucher_ux: number preprinted vouchers on validation

### DIFF
--- a/stock_voucher_ux/models/ir_actions_report.py
+++ b/stock_voucher_ux/models/ir_actions_report.py
@@ -2,11 +2,99 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import io
+import logging
+import re
+
 from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from PyPDF2 import PdfFileReader
+except ImportError:  # pragma: no cover
+    _logger.debug("PyPDF2 could not be imported; voucher page counting is disabled.")
+    PdfFileReader = None
 
 
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
+
+    def _get_voucher_copies(self):
+        """Copias por hoja que imprime el reporte, para no contar la misma hoja
+        más de una vez. Aeroo lo expresa en ``copies`` (entero) y el recibo de
+        entrega argentino en ``l10n_ar_copies``."""
+        self.ensure_one()
+        if self._fields.get("copies") and self.copies:
+            return self.copies
+        if self._fields.get("l10n_ar_copies"):
+            return {"duplicado": 2, "triplicado": 3}.get(self.l10n_ar_copies, 0)
+        return 0
+
+    def _count_voucher_pages(self, picking, data=None):
+        """Cuántos remitos hay que asignar según las páginas REALES del reporte.
+
+        Renderiza el reporte (todavía sin números) y cuenta las páginas con
+        productos, acotadas por las páginas sin copias. Devuelve ``None`` si no se
+        pudo renderizar o parsear: preferimos no numerar antes que subnumerar un
+        talonario preimpreso con una cantidad inventada.
+        """
+        self.ensure_one()
+        if PdfFileReader is None:
+            return None
+        try:
+            # ``report_pdf_no_attachment`` es imprescindible: sin él este render de
+            # conteo se guardaría como adjunto del reporte y, si el reporte tiene
+            # ``attachment_use``, toda impresión posterior reusaría ese PDF — que
+            # todavía no tiene los números que asignamos justo después.
+            content = self.with_context(report_pdf_no_attachment=True)._render(
+                self.report_name, picking.ids, data=data
+            )[0]
+            reader = PdfFileReader(io.BytesIO(content))
+            pages_with_products = self._count_pages_with_products(reader, picking)
+            copies = self._get_voucher_copies()
+            if copies:
+                return max(1, min(pages_with_products, int(len(reader.pages) / copies)))
+            return max(1, pages_with_products)
+        except Exception:  # noqa: BLE001 - cualquier problema de render/parseo -> no numerar
+            _logger.warning("No se pudieron contar las páginas del remito de %s", picking.display_name, exc_info=True)
+            return None
+
+    def _count_pages_with_products(self, pdf_reader, picking):
+        """Cuenta las páginas que realmente tienen productos, matcheando
+        identificadores de producto (referencia interna / código de barras) en el
+        texto de la página, de forma independiente del idioma."""
+        move_lines = picking.move_line_ids or picking.move_ids
+
+        product_identifiers = set()
+        for line in move_lines:
+            product = line.product_id
+            if not product:
+                continue
+            if product.default_code:
+                product_identifiers.add(product.default_code.lower().strip())
+            if product.barcode:
+                product_identifiers.add(product.barcode.lower().strip())
+
+        pages_with_products = 0
+        for page_num in range(len(pdf_reader.pages)):
+            try:
+                text = pdf_reader.pages[page_num].extract_text()
+                if not text:
+                    continue
+                text_lower = text.lower()
+                if product_identifiers and any(pid in text_lower for pid in product_identifiers):
+                    has_products = True
+                else:
+                    # Fallback: patrón numérico genérico (independiente del idioma).
+                    has_products = bool(re.search(r"\b\d+[.,]\d+\b", text_lower))
+                if has_products:
+                    pages_with_products += 1
+            except Exception:  # noqa: BLE001 - si no se puede extraer texto asumimos que tiene productos
+                pages_with_products += 1
+
+        # Siempre hay al menos una página con productos.
+        return max(1, pages_with_products)
 
     def _get_voucher_copies_from_url(self, url):
         """Copias (campo aeroo ``copies``) del reporte que se imprime,

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -35,6 +35,34 @@ class StockPicking(models.Model):
             self.book_id = self.book_id.id
         return super(StockPicking, self).do_print_voucher()
 
+    def _get_voucher_report(self):
+        """Reporte que efectivamente se imprime como remito para este picking: el
+        recibo de entrega nativo, o el remito que lo sustituye cuando
+        ``report_substitute`` tiene una regla para su talonario."""
+        self.ensure_one()
+        report = self.env.ref("stock.action_report_delivery")
+        # ``report_substitute`` es opcional: sin él el reporte es el nativo.
+        if hasattr(report, "get_substitution_report"):
+            report = report.get_substitution_report(self.ids)
+        return report
+
+    def _assign_preprinted_numbers(self):
+        """Numera los remitos preimpresos server-side, según las páginas reales.
+
+        El camino de impresión numera en el controller ``/report/download`` o en
+        ``render_and_send`` (IoT), y los dos dependen de que un cliente web ejecute
+        la acción de reporte. Cuando valida una automatización server-side —la de
+        entregas del tipo de pedido de venta— esa acción se descarta y el remito
+        queda validado sin número. Numerando acá los otros dos caminos quedan
+        no-op, porque ambos chequean que no haya números todavía.
+        """
+        for picking in self.filtered(lambda p: p.book_id and not p.book_id.autoprinted and not p.voucher_ids):
+            number_of_pages = picking._get_voucher_report()._count_voucher_pages(picking)
+            # Sin páginas reales no inventamos una cantidad: que numere el camino
+            # de impresión, como antes.
+            if number_of_pages:
+                picking.assign_numbers(number_of_pages, picking.book_id)
+
     def do_print_and_assign(self):
         if not self.book_id and self.picking_type_code != "incoming":
             raise UserError("Primero debe seleccionar un talonario")
@@ -42,10 +70,12 @@ class StockPicking(models.Model):
             # Talonario preimpreso: la cantidad de remitos debe coincidir con las
             # páginas REALES del reporte. No pre-asignamos por la estimación
             # ``lines_per_voucher`` (subnumera: p. ej. asigna 3 cuando el remito
-            # tiene 5 páginas). Imprimimos con ``assign=True`` para que el
-            # controller cuente las páginas renderizadas, asigne los números y
-            # re-renderice el PDF ya con los números puestos.
+            # tiene 5 páginas). Numeramos server-side contando las páginas del
+            # render, así el número no depende de que alguien ejecute la acción que
+            # devolvemos, e imprimimos con ``assign=True`` para que el controller
+            # numere igual si acá no se pudo renderizar.
             self.printed = True
+            self._assign_preprinted_numbers()
             return self.with_context(assign=True).do_print_voucher()
         else:
             if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):

--- a/stock_voucher_ux/tests/test_remito_preimpreso.py
+++ b/stock_voucher_ux/tests/test_remito_preimpreso.py
@@ -2,15 +2,25 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import io
+from unittest.mock import patch
+
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
 
 
 class TestRemitoPreimpresoNumbering(TransactionCase):
     """Numeración de remitos según el tipo de talonario.
 
-    Preimpreso (``autoprinted=False``): NO se numera en la validación por la
-    estimación ``lines_per_voucher`` (subnumera). La cantidad se determina al
-    imprimir, según las páginas reales del reporte (controller).
+    Preimpreso (``autoprinted=False``): NUNCA se numera por la estimación
+    ``lines_per_voucher`` (subnumera). La cantidad sale de las páginas reales del
+    reporte. Si el tipo de operación pide imprimir al validar
+    (``auto_print_delivery_slip``) se numera en la validación, renderizando y
+    contando server-side, para no depender de que un cliente web ejecute la acción
+    de reporte; si no se pueden contar las páginas no se numera y queda para el
+    camino de impresión (controller / IoT).
 
     Autoimpreso (``autoprinted=True``): se numera en la validación sólo si el
     tipo de operación pide imprimir el remito al validar
@@ -51,6 +61,7 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
             {
                 "name": "Producto remito test",
                 "type": "consu",
+                "default_code": "REMTEST1",
             }
         )
         cls.src = cls.env.ref("stock.stock_location_stock")
@@ -113,6 +124,67 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
             1,
             "Un talonario autoimpreso debe asignar un único remito en la validación "
             "cuando el tipo de operación tiene auto_print_delivery_slip.",
+        )
+
+    def _pdf_with_pages(self, pages):
+        """PDF de ``pages`` páginas, cada una con el código del producto, para que
+        el conteo de páginas con productos sea determinístico (no dependemos de
+        wkhtmltopdf ni de LibreOffice para renderizar el remito de verdad)."""
+        buff = io.BytesIO()
+        pdf = canvas.Canvas(buff, pagesize=A4)
+        for _page in range(pages):
+            pdf.drawString(100, 700, "%s x 1,00" % self.product.default_code)
+            pdf.showPage()
+        pdf.save()
+        return buff.getvalue()
+
+    def test_preprinted_numbered_on_validation_with_flag(self):
+        # Ticket 124899: con auto_print_delivery_slip la validación tiene que dejar
+        # el remito numerado, y con un número por página real. Antes del fix
+        # do_print_and_assign marcaba printed=True y devolvía la acción de reporte:
+        # el número lo asignaba recién el controller /report/download cuando un
+        # cliente web ejecutaba esa acción. Si valida una automatización
+        # server-side (la del tipo de pedido de venta, que descarta el retorno) el
+        # picking quedaba done, printed y SIN número.
+        report_cls = type(self.env["ir.actions.report"])
+        pdf = self._pdf_with_pages(2)
+        render_context = {}
+
+        def _fake_render(report, *args, **kwargs):
+            render_context.update(report.env.context)
+            return (pdf, "pdf")
+
+        with patch.object(report_cls, "_render", autospec=True, side_effect=_fake_render):
+            picking = self._make_done_picking(self.book_pre, auto_print=True)
+        self.assertEqual(picking.state, "done")
+        self.assertTrue(
+            render_context.get("report_pdf_no_attachment"),
+            "El render de conteo no se debe guardar como adjunto: con attachment_use, "
+            "toda impresión posterior reusaría ese PDF, que todavía no tiene números.",
+        )
+        self.assertEqual(
+            len(picking.voucher_ids),
+            2,
+            "Con auto_print_delivery_slip el talonario preimpreso debe quedar numerado en "
+            "la validación, con un remito por página real del reporte, sin depender de que "
+            "un cliente web ejecute la acción que devuelve button_validate.",
+        )
+
+    # El aviso de que no se pudieron contar las páginas es justo lo que este test
+    # provoca, así que lo silenciamos: si no, el traceback ensucia el log y runbot
+    # marca la build en rojo aunque los tests pasen.
+    @mute_logger("odoo.addons.stock_voucher_ux.models.ir_actions_report")
+    def test_preprinted_not_numbered_when_pages_cannot_be_counted(self):
+        # Si el reporte no se puede renderizar o parsear como PDF (p. ej. devuelve
+        # HTML), no inventamos una cantidad: preferimos no numerar y dejar el número
+        # al camino de impresión, antes que subnumerar un talonario preimpreso.
+        report_cls = type(self.env["ir.actions.report"])
+        with patch.object(report_cls, "_render", return_value=(b"<!DOCTYPE html><html></html>", "html")):
+            picking = self._make_done_picking(self.book_pre, auto_print=True)
+        self.assertEqual(picking.state, "done")
+        self.assertFalse(
+            picking.voucher_ids,
+            "Sin páginas reales no se debe numerar el talonario preimpreso en la validación.",
         )
 
     def test_autoprinted_not_assigned_without_flag(self):

--- a/stock_voucher_ux_iot/models/ir_actions_report.py
+++ b/stock_voucher_ux_iot/models/ir_actions_report.py
@@ -2,19 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-import io
-import logging
-import re
-
 from odoo import models
-
-_logger = logging.getLogger(__name__)
-
-try:
-    from PyPDF2 import PdfFileReader
-except ImportError:  # pragma: no cover
-    _logger.debug("PyPDF2 could not be imported; voucher page counting will fall back to 1.")
-    PdfFileReader = None
 
 
 class IrActionsReport(models.Model):
@@ -56,63 +44,9 @@ class IrActionsReport(models.Model):
             # print must not burn extra sequence numbers).
             if not book or book.autoprinted or picking.voucher_ids:
                 continue
-            number_of_pages = self._count_voucher_pages(picking, data=data)
+            # The document is already on its way to the printer, so when the page
+            # count cannot be determined we still assign a single voucher instead
+            # of letting the paper come out unnumbered.
+            number_of_pages = self._count_voucher_pages(picking, data=data) or 1
             picking.assign_numbers(number_of_pages, book)
             picking.env.flush_all()
-
-    def _count_voucher_pages(self, picking, data=None):
-        """Render the report once (numbers not assigned yet) and count the real
-        number of pages that contain products, capped by the page count without
-        copies. Falls back to a single voucher when the output cannot be parsed
-        as a multi-page PDF (e.g. ``.doc`` output)."""
-        self.ensure_one()
-        if PdfFileReader is None:
-            return 1
-        try:
-            content = self._render(self.report_name, picking.ids, data=data)[0]
-            reader = PdfFileReader(io.BytesIO(content))
-            pages_with_products = self._count_pages_with_products(reader, picking)
-            copies = self.copies or 0
-            if copies:
-                total_pages = int(len(reader.pages) / copies)
-                return max(1, min(pages_with_products, total_pages))
-            return max(1, pages_with_products)
-        except Exception:  # noqa: BLE001 - any render/parse issue -> single voucher
-            return 1
-
-    def _count_pages_with_products(self, pdf_reader, picking):
-        """Count the pages that actually contain products by matching product
-        identifiers (internal reference / barcode) in the page text, in a
-        language independent way. Mirrors the logic used by the download
-        controller in ``stock_voucher_ux``."""
-        move_lines = picking.move_line_ids or picking.move_ids
-
-        product_identifiers = set()
-        for line in move_lines:
-            product = line.product_id
-            if not product:
-                continue
-            if product.default_code:
-                product_identifiers.add(product.default_code.lower().strip())
-            if product.barcode:
-                product_identifiers.add(product.barcode.lower().strip())
-
-        pages_with_products = 0
-        for page_num in range(len(pdf_reader.pages)):
-            try:
-                text = pdf_reader.pages[page_num].extract_text()
-                if not text:
-                    continue
-                text_lower = text.lower()
-                if product_identifiers and any(pid in text_lower for pid in product_identifiers):
-                    has_products = True
-                else:
-                    # Fallback: generic numeric pattern (language independent).
-                    has_products = bool(re.search(r"\b\d+[.,]\d+\b", text_lower))
-                if has_products:
-                    pages_with_products += 1
-            except Exception:  # noqa: BLE001 - if text can't be extracted assume it has products
-                pages_with_products += 1
-
-        # There is always at least one page with products.
-        return max(1, pages_with_products)


### PR DESCRIPTION
## Problema

El número de un remito de talonario **preimpreso** se asignaba únicamente aguas abajo del render del reporte:

- por el controller `/report/download` de `stock_voucher_ux`, o
- por el override de `render_and_send` de `stock_voucher_ux_iot`, en el camino IoT.

Los dos necesitan que **un cliente web ejecute la acción de reporte** que devuelve `button_validate`. Cuando la validación ocurre server-side, esa acción se descarta y el picking queda validado, marcado como `printed` y **sin número de remito**. Es lo que pasa cuando valida la automatización de entregas de un tipo de pedido de venta.

## Cambio

- `do_print_and_assign` numera server-side, contando las **páginas reales** del reporte renderizado.
- Los helpers de conteo (`_count_voucher_pages`, `_count_pages_with_products`) se mueven de `stock_voucher_ux_iot` a `stock_voucher_ux`, así los comparten todos los caminos.
- El reporte a renderizar se resuelve por las reglas de sustitución (`_get_voucher_report`), así que también cubre los talonarios que imprimen el recibo de entrega nativo (qweb) en vez de un remito aeroo — hasta ahora el guard del puente IoT (aeroo + `remito` en el `report_name`) no los alcanzaba.
- El controller y el override de IoT quedan no-op cuando ya hay números: ambos saltean los pickings con remitos asignados.

`_count_voucher_pages` ahora devuelve `None` si el reporte no se puede renderizar o parsear, en vez de caer a un remito. Numerar un talonario preimpreso con una cantidad inventada subnumera un documento fiscal, así que preferimos no numerar y dejarlo al camino de impresión. En IoT se mantiene el fallback a 1, porque ahí el documento ya va camino a la impresora y que salga sin número es peor.

No cambia el contrato de que un preimpreso **nunca** se numera por la estimación `lines_per_voucher`.

## Test plan

`stock_voucher_ux/tests/test_remito_preimpreso.py`, dos tests nuevos:

- `test_preprinted_numbered_on_validation_with_flag`: con `auto_print_delivery_slip`, validar deja el remito numerado con un número por página real (PDF de 2 páginas armado con reportlab, `_render` patcheado para no depender de wkhtmltopdf).
- `test_preprinted_not_numbered_when_pages_cannot_be_counted`: si el render no se puede parsear como PDF, no se numera.

Los 3 tests preexistentes de la clase siguen verdes (preimpreso sin flag no se numera; autoimpreso con y sin flag). Los 5 de `stock_voucher_ux_iot` también.

Verificado con `-u stock_voucher_ux,stock_voucher_ux_iot,sale_order_type_automation --test-enable` sobre una base 18.0: **3 failed sin el fix / 0 failed con el fix** de 13 tests (los otros 3 fallos son del PR del repo `sale`, mismo branch).

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124899

## Notas para el review

- **El mail de confirmación de entrega vuelve a salir en este flujo.** `stock_ux._send_confirmation_email` lo manda sólo cuando viene desde `assign_numbers`, así que si nadie imprimía el remito, el cliente tampoco recibía el mail. Sigue siendo uno solo: el controller y el camino IoT saltean los pickings que ya tienen números.
- **Complementa a #974**, sin archivos en común: ese PR arregla el guard del controller para el remito aeroo sustituido (camino de impresión manual); este numera en la validación, que es el camino donde no hay cliente web que ejecute la acción. Ninguno reemplaza al otro.
