### PR TITLE
[FIX] sale_order_type_invoice_policy_invoice_link: replace process-wide monkey patch with model inheritance

### DIFF
--- a/sale_order_type_invoice_policy_invoice_link/models/stock_move.py
+++ b/sale_order_type_invoice_policy_invoice_link/models/stock_move.py
@@ -1,33 +1,28 @@
-from odoo import _
-from odoo.addons.stock_picking_invoice_link.models.stock_move import StockMove
-from odoo.exceptions import UserError
+from odoo import Command, models
 
 
-def new_write(self, vals):
-    # monkey patch to take in consideration both module stock_picking_invoice_link and sale_order_type_invoice_policy
-    if "product_uom_qty" in vals and not self.env.context.get("bypass_stock_move_update_restriction"):
-        for move in self:
-            if move.state == "done" and move.invoice_line_ids:
-                raise UserError(_("You can not modify an invoiced stock move"))
-    res = super(StockMove, self).write(vals)
-    if vals.get("state", "") == "done":
-        stock_moves = self.get_moves_delivery_link_invoice()
-        for stock_move in stock_moves.filtered(lambda sm: sm.sale_line_id):
-            invoice_policy = stock_move.sudo().sale_line_id.order_id.type_id.invoice_policy
-            if not (
-                invoice_policy == "order"
-                or (invoice_policy == "by_product" and stock_move.product_id.invoice_policy == "order")
-            ):
-                continue
-            inv_type = stock_move.to_refund and "out_refund" or "out_invoice"
-            inv_line = (
-                self.env["account.move.line"]
-                .sudo()
-                .search([("sale_line_ids", "=", stock_move.sale_line_id.id), ("move_id.move_type", "=", inv_type)])
-            )
-            if inv_line:
-                stock_move.invoice_line_ids = [(4, m.id) for m in inv_line]
-    return res
+class StockMove(models.Model):
+    _inherit = "stock.move"
 
-
-StockMove.write = new_write
+    def write(self, vals):
+        # bridge between stock_picking_invoice_link and sale_order_type_invoice_policy: link the invoice lines
+        # also when the invoicing policy comes from the sale order type instead of from the product
+        res = super().write(vals)
+        if vals.get("state", "") == "done":
+            stock_moves = self.get_moves_delivery_link_invoice()
+            for stock_move in stock_moves.filtered(lambda sm: sm.sale_line_id):
+                invoice_policy = stock_move.sudo().sale_line_id.order_id.type_id.invoice_policy
+                if not (
+                    invoice_policy == "order"
+                    or (invoice_policy == "by_product" and stock_move.product_id.invoice_policy == "order")
+                ):
+                    continue
+                inv_type = stock_move.to_refund and "out_refund" or "out_invoice"
+                inv_line = (
+                    self.env["account.move.line"]
+                    .sudo()
+                    .search([("sale_line_ids", "=", stock_move.sale_line_id.id), ("move_id.move_type", "=", inv_type)])
+                )
+                if inv_line:
+                    stock_move.invoice_line_ids = [Command.link(line_id) for line_id in inv_line.ids]
+        return res


### PR DESCRIPTION
## Problem

`models/stock_move.py` patched `stock_picking_invoice_link`'s `StockMove.write` at import time:

```python
from odoo.addons.stock_picking_invoice_link.models.stock_move import StockMove
def new_write(self, vals): ...
StockMove.write = new_write
```

That mutates the class object for the **whole Odoo process**, and nothing ever undoes it. Uninstalling this module removes its models from the registry but does **not** un-import the Python module nor restore the original `write`. The patched body reads `sale_line_id.order_id.type_id.invoice_policy`, a field contributed by `sale_order_type_invoice_policy`, so once that field is gone every picking validation crashes until the worker is restarted.

Reproduced on a production database:

1. Install `sale_order_type_invoice_policy` — `sale_order_type_invoice_policy_invoice_link` auto-installs and the patch is applied to the class.
2. Uninstall it ~45 seconds later. The registry reloads without `sale.order.type.invoice_policy`, but the patched `write` is still in place.
3. Validate any delivery, the next day, on the same worker:

```
File ".../stock/models/stock_move.py", line 2111, in _action_done
    moves_todo.write({'state': 'done', 'date': fields.Datetime.now()})
File ".../sale_order_type_invoice_policy_invoice_link/models/stock_move.py", line 16, in new_write
    invoice_policy = stock_move.sudo().sale_line_id.order_id.type_id.invoice_policy
AttributeError: 'sale.order.type' object has no attribute 'invoice_policy'
```

23 consecutive failures over ~50 minutes, from a module that was not installed on that database.

## Fix

Use a regular `_inherit = "stock.move"` override. The code then lives in the registry instead of in the class object, so it is present exactly when the module is installed and gone as soon as it is uninstalled. That removes the whole class of failure rather than guarding against this one symptom.

Also drops the duplicated `You can not modify an invoiced stock move` check: the monkey patch had to reimplement it because it was *replacing* `stock_picking_invoice_link.write`. With normal inheritance that check runs through `super()` again.

Business logic is unchanged — invoice lines are still linked when the sale order type policy is `order`, or when it is `by_product` and the product policy is `order`.

## Test plan

- With `sale_order_type_invoice_policy` and this module installed: create a `sale.order.type` with `invoice_policy = 'order'`, confirm a SO with that type, invoice it, validate the delivery, and check `stock.move.invoice_line_ids` is populated. Same behaviour as before.
- Install both modules, uninstall them, then validate a delivery **without restarting the worker**: no longer raises `AttributeError`. This is the regression that motivated the change.
- Modifying `product_uom_qty` on a done move that has linked invoice lines still raises the `UserError`.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/124767