### PR TITLE
[FIX] stock_currency_valuation: fix revaluation in secondary currency

### DIFF
--- a/stock_currency_valuation/models/product_template.py
+++ b/stock_currency_valuation/models/product_template.py
@@ -47,7 +47,11 @@ class productTemplate(models.Model):
             )
 
     @api.depends_context("company")
-    @api.depends("product_variant_ids", "product_variant_ids.standard_price")
+    @api.depends(
+        "product_variant_ids",
+        "product_variant_ids.standard_price",
+        "product_variant_ids.standard_price_in_currency",
+    )
     def _compute_standard_price_in_currency(self):
         # Por ahora hacemos esto porque replishment cost no es compatible al 100% con variantes
         # obtenemos el precio del primer producto

--- a/stock_currency_valuation/tests/__init__.py
+++ b/stock_currency_valuation/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_revaluation_in_currency

--- a/stock_currency_valuation/tests/test_revaluation_in_currency.py
+++ b/stock_currency_valuation/tests/test_revaluation_in_currency.py
@@ -1,0 +1,54 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestRevaluationInCurrency(TransactionCase):
+    def test_revaluation_updates_standard_price_in_currency(self):
+        """La revaluacion tiene que impactar el costo en moneda secundaria de la ficha."""
+        company = self.env.company
+        categ = self.env["product.category"].create(
+            {
+                "name": "Categoria valuada en moneda",
+                "property_cost_method": "average",
+                "property_valuation": "manual_periodic",
+                "valuation_currency_id": self.env.ref("base.USD").id,
+            }
+        )
+        product = (
+            self.env["product.product"]
+            .create({"name": "Producto valuado en moneda", "is_storable": True, "categ_id": categ.id})
+            .with_company(company)
+        )
+        product.standard_price = 1000.0
+        product.standard_price_in_currency = 1.0
+
+        # ingreso 2 unidades por ajuste de inventario para tener layers con remaining_qty
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", company.id)], limit=1)
+        self.env["stock.quant"].with_context(inventory_mode=True).create(
+            {
+                "product_id": product.id,
+                "location_id": warehouse.lot_stock_id.id,
+                "inventory_quantity": 2.0,
+            }
+        ).action_apply_inventory()
+
+        wizard = (
+            self.env["stock.valuation.layer.revaluation"]
+            .with_company(company)
+            .create({"product_id": product.id, "added_value": 2000.0, "reason": "test"})
+        )
+        expected = 1.0 + wizard.added_value_in_currency / 2.0
+        # el preview del wizard tiene que anticipar el costo que va a quedar en la ficha
+        self.assertAlmostEqual(wizard.new_value_in_currency, expected * 2.0, places=2)
+        self.assertAlmostEqual(wizard.new_value_in_currency_by_qty, expected, places=2)
+
+        wizard.action_validate_revaluation()
+
+        self.assertAlmostEqual(product.standard_price, 2000.0, places=2)
+        self.assertAlmostEqual(product.standard_price_in_currency, expected, places=2)
+        # esta lectura ademas cachea el valor del template para el chequeo de abajo
+        self.assertAlmostEqual(product.product_tmpl_id.standard_price_in_currency, expected, places=2)
+
+        # si solo se mueve el costo en moneda (ej. un landed cost), el template tiene que seguirlo
+        product.standard_price_in_currency = 5.0
+        self.assertAlmostEqual(product.product_tmpl_id.standard_price_in_currency, 5.0, places=2)

--- a/stock_currency_valuation/wizard/stock_valuation_layer_revaluation.py
+++ b/stock_currency_valuation/wizard/stock_valuation_layer_revaluation.py
@@ -26,7 +26,7 @@ class StockValuationLayerRevaluation(models.TransientModel):
     )
     new_value_in_currency_by_qty = fields.Monetary(
         "New value in currency by quantity",
-        compute="_compute_new_value",
+        compute="_compute_new_value_in_currency",
     )
 
     @api.depends("product_id", "company_id")
@@ -69,8 +69,11 @@ class StockValuationLayerRevaluation(models.TransientModel):
     def _compute_new_value_in_currency(self):
         for reval in self:
             product_id = reval.product_id.with_company(reval.company_id)
-            reval.new_value_in_currency = product_id.standard_price_in_currency + reval.added_value_in_currency
-            if not float_is_zero(reval.current_quantity_svl, precision_rounding=self.product_id.uom_id.rounding):
+            # standard_price_in_currency es el costo unitario: hay que llevarlo a valor total
+            # antes de sumarle el valor agregado, igual que el nativo con current_value_svl.
+            current_value_in_currency = product_id.standard_price_in_currency * reval.current_quantity_svl
+            reval.new_value_in_currency = current_value_in_currency + reval.added_value_in_currency
+            if not float_is_zero(reval.current_quantity_svl, precision_rounding=reval.product_id.uom_id.rounding):
                 reval.new_value_in_currency_by_qty = reval.new_value_in_currency / reval.current_quantity_svl
             else:
                 reval.new_value_in_currency_by_qty = 0.0
@@ -107,6 +110,12 @@ class StockValuationLayerRevaluation(models.TransientModel):
                     lot_id.with_context(disable_auto_svl=True).standard_price += self.added_value / total_product_qty
                 product_id.with_context(disable_auto_svl=True).standard_price += (
                     self.added_value / product_id.quantity_svl
+                )
+                # El costo en moneda secundaria no lo actualiza ningun otro camino: el
+                # _update_currency_standard_price del layer solo corre para landed costs
+                # y el layer de revaluacion no tiene, asi que se actualiza aca.
+                product_id.with_context(disable_auto_svl=True).standard_price_in_currency += (
+                    self.added_value_in_currency / product_id.quantity_svl
                 )
                 if self.lot_id:
                     description += _(


### PR DESCRIPTION
Three defects on the revaluation of a product whose category has a secondary
valuation currency (`property_cost_method` in average/fifo + `valuation_currency_id`).

## 1. The cost in currency was never written

The module was created on 16.0 with an explicit line updating
`standard_price_in_currency`, with a comment stating why. The 18.0 migration
(`8bfae6a`, #685) rewrote `action_validate_revaluation()` as a full copy of the new
native method — `lot_valuated`, `adjusted_layer_ids` and the per-layer distribution
made the old `super()`-with-context approach unusable — and the line was not carried
over. The valuation layer and the journal entry were right in the secondary currency,
but the product form kept the old value.

The only other path that writes that field,
`stock.valuation.layer._update_currency_standard_price()`, is filtered to layers with
a `stock_landed_cost_id`, and the revaluation layer has none.

The added value in currency is divided by `product_id.quantity_svl`, the same divisor
the native code uses on the line right above for `standard_price`, so both costs stay
on the same basis when the revaluation targets specific layers.

## 2. The wizard preview mixed a unit cost with a total value

`_compute_new_value_in_currency` computed
`standard_price_in_currency + added_value_in_currency`. The native code adds
`current_value_svl` (a total) to `added_value`, so the figures on screen did not match
the cost that ended up on the product.

With 10 units at 10 in the secondary currency and an added value of 50, the wizard
showed `60` (`6` by unit) where it should show `150` (`15` by unit) — and `15` is what
the product form correctly gets after validating.

## 3. `new_value_in_currency_by_qty` pointed at the wrong compute

It declared `_compute_new_value` (the native method), which never assigns it. It only
resolved because reading `new_value_in_currency` first filled the cache.

## Also

`_compute_standard_price_in_currency` on `product.template` only tracked the variant
`standard_price`, so a change that moved only the cost in currency (a landed cost, for
instance) left the template showing a stale value. The existing `standard_price`
dependency is kept — the field is not stored and that dependency drives the onchange in
the product form.

## Test plan

```
odoo -d <db> -u stock_currency_valuation --test-enable --test-tags=/stock_currency_valuation
```

One test covers the four cases; reverting any single hunk makes it fail:

- wizard write: `AssertionError: 1.0 != 1001.0`
- preview total: `AssertionError: 2001.0 != 2002.0`
- template depends: `AssertionError: 1001.0 != 5.0`

Manual check: on a category with a secondary valuation currency, revaluate a product
with stock and confirm the wizard preview, the resulting "Cost in currency" on the
product form and the layer `value_in_currency` all agree.

## Notes

- 19.0 carries the same defects — a forward port is needed.
- Not covered here: with `lot_valuated` and a lot selected, the cost in company currency
  is updated on the lot but there is no equivalent field in the secondary currency on
  `stock.lot`.