### PR TITLE
[ADD] stock_currency_valuation_recompute: repair tool for values in currency

### DIFF
--- a/stock_currency_valuation_recompute/README.rst
+++ b/stock_currency_valuation_recompute/README.rst
@@ -1,0 +1,101 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Stock Currency Valuation Recompute
+==================================
+
+Repair tool for databases where the cost in the secondary currency drifted away
+from the valuation layers.
+
+When a revaluation does not write ``standard_price_in_currency`` on the product,
+every later layer is valued from that stale cost: outgoing moves take
+``standard_price_in_currency * quantity`` and incoming moves re-average on top of
+it. Setting the cost on the product afterwards does not repair that history.
+
+This module adds a tool that replays the whole valuation history of a product in
+chronological order, computes what each layer should have been, shows the old and
+the new values side by side, and only on confirmation writes the corrected values
+back to the layers, their journal entries and the product cost.
+
+**Manual adjustments are respected.** Only the layers created after the last manual
+valuation of the product are adjusted; that adjustment and everything before it are
+left exactly as they are. Without this cut, an adjustment that was compensating for a
+badly valued layer ends up counted twice: once in the recomputed layer and again in
+the adjustment that is still there.
+
+The layers before the cut still take part in the replay, but with their recorded
+values, not the recomputed ones. They are not going to be written, so the average
+cost has to advance with what will actually remain in the database — otherwise the
+product ends up with a cost derived from a history that does not exist, and it does
+not add up against the valuation report.
+
+It is meant to be installed on an affected database, run once per product, and
+uninstalled afterwards. It does not change any standard behaviour while installed.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to Inventory / Reporting / Layer recompute
+#. Create a record, choose the product and press "Compute lines"
+#. Review the proposed values, they are not written yet
+#. Press "Revaluate" to apply them
+
+Known issues / Roadmap
+======================
+
+* Products with valuation per lot (``lot_valuated``) are not supported, the tool
+  works at product level and raises instead of writing wrong costs.
+* Layers coming from a landed cost are not adjusted.
+* ``remaining_qty`` and ``remaining_value`` are not rewritten.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/ingadhoc/stock/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/stock_currency_valuation_recompute/__init__.py
+++ b/stock_currency_valuation_recompute/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_currency_valuation_recompute/__manifest__.py
+++ b/stock_currency_valuation_recompute/__manifest__.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Currency Valuation Recompute",
+    "version": "18.0.1.0.0",
+    "category": "Warehouse Management",
+    "sequence": 14,
+    "summary": "Repair tool to recompute stock valuation layer values in the secondary currency",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "stock_currency_valuation",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/stock_valuation_layer_recompute.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/stock_currency_valuation_recompute/models/__init__.py
+++ b/stock_currency_valuation_recompute/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_valuation_layer_recompute

--- a/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
+++ b/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
@@ -1,0 +1,476 @@
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class StockValuationLayerRecompute(models.Model):
+    _name = "stock.valuation.layer.recompute"
+    _description = "layer recompute"
+
+    company_id = fields.Many2one("res.company", default=lambda self: self.env.company)
+    currency_id = fields.Many2one("res.currency", related="company_id.currency_id")
+    product_id = fields.Many2one("product.product", string="Product", readonly=False)
+    valuation_currency_id = fields.Many2one(
+        "res.currency", string="Secondary Currency Valuation", compute="_compute_valuation_currency_id"
+    )
+    initial_amount = fields.Monetary()
+    final_amount = fields.Monetary()
+    initial_amount_in_currency = fields.Monetary()
+    final_amount_in_currency = fields.Monetary()
+    line_ids = fields.One2many(
+        comodel_name="stock.valuation.layer.recompute.line",
+        inverse_name="recompute_id",
+    )
+    last_manual_svl_id = fields.Many2one("stock.valuation.layer")
+    amount_changed = fields.Boolean()
+    slv_changed = fields.Boolean()
+    final_rate = fields.Float(
+        compute="_compute_final_rate",
+        store=True,
+    )
+
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("in_process", "In Process"),
+            ("done", "Done"),
+            ("no_change", "Not changes Required"),
+            ("cancel", "Cancelled"),
+        ],
+        default="draft",
+        string="Status",
+        required=True,
+        readonly=True,
+        copy=False,
+    )
+
+    @api.depends("final_amount", "final_amount_in_currency")
+    def _compute_final_rate(self):
+        for rec in self:
+            if rec.final_amount_in_currency:
+                rec.final_rate = rec.final_amount / rec.final_amount_in_currency
+            else:
+                rec.final_rate = 0.0
+
+    @api.onchange("product_id", "company_id")
+    def _onchange_product_id(self):
+        self.line_ids = False
+        self.final_amount_in_currency = False
+
+    @api.depends("product_id", "company_id")
+    def _compute_valuation_currency_id(self):
+        for rec in self:
+            product_id = rec.product_id.with_company(rec.company_id)
+            rec.valuation_currency_id = product_id.categ_id.valuation_currency_id
+
+    def action_cancel(self):
+        for rec in self:
+            rec.state = "cancel"
+
+    def back_to_draft(self):
+        for rec in self:
+            rec.state = "draft"
+
+    def _get_manual_svl_domain(self):
+        """Ajustes manuales del producto: un layer cargado a mano no tiene movimiento de
+        stock, ni linea de factura, ni landed cost.
+
+        No se filtra por `create_uid`: el ajuste lo carga quien opera, no un usuario
+        tecnico, y filtrarlo hace que no se encuentre ninguno y se recalcule tambien lo
+        anterior al ajuste, que es justamente lo que hay que respetar.
+
+        `account_move_line_id` descarta las diferencias de precio de factura, que tampoco
+        tienen movimiento de stock pero no son un ajuste manual: si se cuelan, el corte
+        queda despues del ajuste real y deja sin recalcular layers que si correspondian.
+        """
+        return [
+            ("company_id", "=", self.company_id.id),
+            ("product_id", "=", self.product_id.id),
+            ("stock_move_id", "=", False),
+            ("account_move_line_id", "=", False),
+            ("stock_landed_cost_id", "=", False),
+        ]
+
+    def _prepare_new_values(self, from_currency_id, to_currency_id, qty, unit_cost, layer_date, manual_currency_rate=0):
+        is_company_currency = from_currency_id == self.company_id.currency_id
+        if manual_currency_rate and is_company_currency:
+            new_unit_cost_in_to_currency = unit_cost * manual_currency_rate
+        elif manual_currency_rate and not is_company_currency:
+            new_unit_cost_in_to_currency = unit_cost / manual_currency_rate
+        else:
+            new_unit_cost_in_to_currency = from_currency_id._convert(
+                from_amount=unit_cost,
+                to_currency=to_currency_id,
+                company=self.company_id,
+                date=layer_date,
+            )
+
+        rate_type = "manual rate" if manual_currency_rate else "slv"
+        if is_company_currency:
+            return [
+                unit_cost,
+                unit_cost * qty,
+                new_unit_cost_in_to_currency,
+                new_unit_cost_in_to_currency * qty,
+                rate_type,
+            ]
+        return [
+            new_unit_cost_in_to_currency,
+            new_unit_cost_in_to_currency * qty,
+            unit_cost,
+            unit_cost * qty,
+            rate_type,
+        ]
+
+    def _get_standard_price(self, new_value, standard_price, quantity_at_time, quantity):
+        if not quantity_at_time:
+            return standard_price
+        return (new_value + standard_price * (quantity_at_time - quantity)) / quantity_at_time
+
+    def _check_supported_product(self):
+        """En 18.0 existe valuacion por lote (`lot_valuated`), que este recalculo no contempla:
+        el costo se lleva a nivel producto y no por `stock.lot`. Frenamos antes de escribir."""
+        if self.product_id.with_company(self.company_id).lot_valuated:
+            raise UserError("El producto tiene valuación por lote (lot_valuated) y este recálculo no la contempla.")
+
+    def action_compute_lines(self):
+        self._check_supported_product()
+
+        last_manual_svl_id = self.env["stock.valuation.layer"].search(
+            self._get_manual_svl_domain(), order="create_date desc", limit=1
+        )
+        self.last_manual_svl_id = last_manual_svl_id
+
+        lines_to_zero = self.env.context.get("lines_to_zero", {})
+
+        leaf = [("company_id", "=", self.company_id.id), ("product_id", "=", self.product_id.id)]
+        svl_ids = self.env["stock.valuation.layer"].search(leaf, order="create_date asc")
+        if not svl_ids:
+            # Sin este aviso el recalculo termina en "Not changes Required", que se lee
+            # como "el producto esta bien" cuando en realidad se miro la compania equivocada.
+            raise UserError(
+                _(
+                    "%(product)s has no valuation layers in %(company)s. "
+                    "Check that you picked the company where the product is valued.",
+                    product=self.product_id.display_name,
+                    company=self.company_id.display_name,
+                )
+            )
+        lines = [Command.clear()]
+        quantity_at_time = 0
+        standard_price_in_currency = 0
+        standard_price = 0
+        description = ""
+
+        self.initial_amount_in_currency = self.product_id.with_company(self.company_id.id).standard_price_in_currency
+        self.initial_amount = self.product_id.with_company(self.company_id.id).standard_price
+        for svl_id in svl_ids:
+            svl_type = ""
+            vals = {
+                "layer_id": svl_id.id,
+                "layer_unit_cost": svl_id.unit_cost,
+                "layer_value": svl_id.value,
+                "layer_unit_cost_in_currency": svl_id.unit_cost_in_currency,
+                "layer_value_in_currency": svl_id.value_in_currency,
+            }
+            quantity_at_time = quantity_at_time + svl_id.quantity
+            after_last_manual = not last_manual_svl_id or svl_id.id > last_manual_svl_id.id
+            if not after_last_manual:
+                # El ajuste manual y todo lo anterior se respeta, asi que estos layers no
+                # se van a escribir. El promedio ponderado tiene que avanzar con el valor
+                # REGISTRADO, que es el que va a quedar, y no con el recalculado: si no,
+                # la ficha termina con un costo que sale de una historia que no existe y
+                # no cierra contra la suma de los layers.
+                new_unit_cost = svl_id.unit_cost
+                new_value = svl_id.value
+                new_unit_cost_in_currency = svl_id.unit_cost_in_currency
+                new_value_in_currency = svl_id.value_in_currency
+                standard_price = self._get_standard_price(new_value, standard_price, quantity_at_time, svl_id.quantity)
+                standard_price_in_currency = self._get_standard_price(
+                    new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                )
+                svl_type = "before adjustment"
+
+            elif svl_id.id in lines_to_zero:
+                new_unit_cost = 0
+                new_value = 0
+                new_unit_cost_in_currency = 0
+                new_value_in_currency = 0
+                quantity_at_time = quantity_at_time - svl_id.quantity
+                svl_type = "zero"
+
+            elif svl_id.stock_move_id and svl_id.stock_move_id.is_inventory:
+                standard_price_in_currency = (
+                    standard_price_in_currency if standard_price_in_currency else svl_id.unit_cost_in_currency
+                )
+                standard_price = standard_price if standard_price else svl_id.unit_cost
+
+                new_unit_cost = standard_price
+                new_value = standard_price * svl_id.quantity
+                new_unit_cost_in_currency = standard_price_in_currency
+                new_value_in_currency = standard_price_in_currency * svl_id.quantity
+                svl_type = "inventory"
+
+            # Si el movimento es de salida o de inventario, valor es el registrado en el producto
+            elif svl_id.stock_move_id and svl_id.stock_move_id._is_out():
+                if len(lines) == 0:
+                    standard_price_in_currency = svl_id.unit_cost_in_currency
+                    standard_price = svl_id.unit_cost
+
+                new_unit_cost = standard_price
+                new_value = standard_price * svl_id.quantity
+                new_unit_cost_in_currency = standard_price_in_currency
+                new_value_in_currency = standard_price_in_currency * svl_id.quantity
+                svl_type = "out"
+
+            # es un ajuste? si no tiene movimiento de stock
+            elif not svl_id.stock_move_id:
+                new_value = svl_id.value
+                new_unit_cost = svl_id.unit_cost
+                new_value_in_currency = svl_id.value_in_currency
+                new_unit_cost_in_currency = svl_id.unit_cost_in_currency
+                standard_price_in_currency = self._get_standard_price(
+                    new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                )
+                standard_price = self._get_standard_price(new_value, standard_price, quantity_at_time, svl_id.quantity)
+                svl_type = "ajustement"
+
+            # Es una devolucion
+            elif svl_id.stock_move_id and svl_id.stock_move_id._is_returned(valued_type="in"):
+                # Si existe el movimiento de origen el valor de avco sale del mov de origen
+                if svl_id.stock_move_id.origin_returned_move_id:
+                    origin_layer_ids = svl_id.stock_move_id.origin_returned_move_id.stock_valuation_layer_ids.ids
+                    for temp_vals in lines:
+                        if temp_vals[2] and temp_vals[2]["layer_id"] in origin_layer_ids:
+                            new_unit_cost_in_currency = temp_vals[2]["new_unit_cost_in_currency"]
+                            new_value_in_currency = new_unit_cost_in_currency * svl_id.quantity
+                            standard_price_in_currency = self._get_standard_price(
+                                new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                            )
+                            new_unit_cost = temp_vals[2]["new_unit_cost"]
+                            new_value = new_unit_cost * svl_id.quantity
+                            standard_price = self._get_standard_price(
+                                new_value, standard_price, quantity_at_time, svl_id.quantity
+                            )
+                            svl_type = "return  of  %s " % temp_vals[2]["layer_id"]
+                            break
+                # sino sale de producto
+                else:
+                    new_value_in_currency = standard_price_in_currency * svl_id.quantity
+                    new_unit_cost_in_currency = standard_price_in_currency
+                    new_value = standard_price * svl_id.quantity
+                    new_unit_cost = standard_price
+                    svl_type = "ret_without_move"
+
+            # landed cost
+            elif svl_id.stock_landed_cost_id:
+                new_value, new_unit_cost, new_value_in_currency, new_unit_cost_in_currency, description = (
+                    self._prepare_new_values(
+                        from_currency_id=self.company_id.currency_id,
+                        to_currency_id=svl_id.stock_landed_cost_id.valuation_currency_id,
+                        qty=svl_id.quantity,
+                        unit_cost=svl_id.value,
+                        layer_date=svl_id.create_date,
+                        manual_currency_rate=svl_id.manual_currency_rate,
+                    )
+                )
+                standard_price = self._get_standard_price(new_value, standard_price, quantity_at_time, svl_id.quantity)
+                standard_price_in_currency = self._get_standard_price(
+                    new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                )
+                svl_type = "landed cost %s" % description
+
+            # purchase refund
+            elif (
+                svl_id.stock_move_id
+                and svl_id.stock_move_id.purchase_line_id
+                and svl_id.stock_move_id.origin_returned_move_id
+            ):
+                origin_layer_ids = svl_id.stock_move_id.origin_returned_move_id.stock_valuation_layer_ids.ids
+                for temp_vals in lines:
+                    if temp_vals[2] and temp_vals[2]["layer_id"] in origin_layer_ids:
+                        new_unit_cost_in_currency = temp_vals[2]["new_unit_cost_in_currency"]
+                        new_value_in_currency = new_unit_cost_in_currency * svl_id.quantity
+                        standard_price_in_currency = self._get_standard_price(
+                            new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                        )
+                        new_unit_cost = temp_vals[2]["new_unit_cost"]
+                        new_value = new_unit_cost * svl_id.quantity
+                        standard_price = self._get_standard_price(
+                            new_value, standard_price, quantity_at_time, svl_id.quantity
+                        )
+                        svl_type = "purchase refund  of  %s " % temp_vals[2]["layer_id"]
+                        break
+
+            # purchase
+            elif svl_id.stock_move_id and svl_id.stock_move_id.purchase_line_id:
+                purchase_currency_id = svl_id.stock_move_id.purchase_line_id.order_id.currency_id
+                if purchase_currency_id == self.company_id.currency_id:
+                    from_currency_id = self.company_id.currency_id
+                    to_currency_id = self.valuation_currency_id
+                else:
+                    from_currency_id = self.valuation_currency_id
+                    to_currency_id = self.company_id.currency_id
+                new_unit_cost, new_value, new_unit_cost_in_currency, new_value_in_currency, description = (
+                    self._prepare_new_values(
+                        from_currency_id=from_currency_id,
+                        to_currency_id=to_currency_id,
+                        qty=svl_id.quantity,
+                        unit_cost=svl_id.stock_move_id.purchase_line_id.price_unit,
+                        layer_date=svl_id.create_date,
+                        manual_currency_rate=svl_id.manual_currency_rate,
+                    )
+                )
+                standard_price = self._get_standard_price(new_value, standard_price, quantity_at_time, svl_id.quantity)
+                standard_price_in_currency = self._get_standard_price(
+                    new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                )
+                svl_type = "Purchase %s" % description
+
+            else:
+                new_unit_cost, new_value, new_unit_cost_in_currency, new_value_in_currency, description = (
+                    self._prepare_new_values(
+                        from_currency_id=self.company_id.currency_id,
+                        to_currency_id=self.valuation_currency_id,
+                        qty=svl_id.quantity,
+                        unit_cost=svl_id.unit_cost,
+                        layer_date=svl_id.create_date,
+                        manual_currency_rate=svl_id.manual_currency_rate,
+                    )
+                )
+                standard_price = self._get_standard_price(new_value, standard_price, quantity_at_time, svl_id.quantity)
+                standard_price_in_currency = self._get_standard_price(
+                    new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
+                )
+                svl_type = "slv %s" % description
+
+            vals["new_value"] = new_value
+            vals["new_unit_cost"] = new_unit_cost
+            vals["standard_price"] = standard_price
+
+            vals["new_value_in_currency"] = new_value_in_currency
+            vals["new_unit_cost_in_currency"] = new_unit_cost_in_currency
+            vals["standard_price_in_currency"] = standard_price_in_currency
+            vals["quantity_at_time"] = quantity_at_time
+            vals["svl_type"] = svl_type
+
+            need_change_1 = self.valuation_currency_id.compare_amounts(svl_id.value_in_currency, new_value_in_currency)
+            need_change_2 = self.valuation_currency_id.compare_amounts(
+                svl_id.unit_cost_in_currency, new_unit_cost_in_currency
+            )
+            need_change_3 = self.currency_id.compare_amounts(svl_id.value, new_value)
+            need_change_4 = self.currency_id.compare_amounts(svl_id.unit_cost, new_unit_cost)
+
+            # Solo se ajusta lo POSTERIOR al ultimo ajuste manual: el ajuste que cargo el
+            # usuario se respeta tal cual, y con el todo lo anterior. Sin este corte, un
+            # ajuste que compensaba un layer mal valuado se termina contando dos veces:
+            # una en el layer recalculado y otra en el ajuste que sigue ahi.
+            need_change_5 = after_last_manual
+            need_change_6 = svl_id.id in lines_to_zero
+            vals["need_changes"] = bool(
+                (need_change_1 or need_change_2 or need_change_3 or need_change_4 or need_change_6) and need_change_5
+            )
+            lines.append(Command.create(vals))
+        self.line_ids = lines
+        self.final_amount_in_currency = standard_price_in_currency
+        self.final_amount = standard_price
+        self.state = "in_process"
+        self.action_check_need_changes()
+
+    def action_check_need_changes(self):
+        if (
+            not self.line_ids.filtered("need_changes")
+            and self.final_amount_in_currency == self.initial_amount_in_currency
+            and self.final_amount == self.initial_amount
+        ):
+            self.state = "no_change"
+
+    def action_manual_slv_revaluation(self):
+        self._check_supported_product()
+        slv_changed = False
+        # to_reconciled_line_ids guarda todas las conciliaciones
+        to_reconciled_line_ids = []
+        for line_id in self.line_ids.filtered("need_changes"):
+            slv_changed = True
+            if line_id.layer_id.stock_landed_cost_id:
+                raise UserError("No puedo ajustar un landed cost")
+            line_id.layer_id.write({"unit_cost": line_id.new_unit_cost, "value": line_id.new_value})
+            # se escribe en dos pasos: el compute de value_in_currency corta si ya tiene valor
+            line_id.layer_id.write(
+                {
+                    "unit_cost_in_currency": line_id.new_unit_cost_in_currency,
+                    "value_in_currency": line_id.new_value_in_currency,
+                }
+            )
+            lines = []
+            product_move_line_ids = line_id.layer_id.account_move_id.line_ids.filtered(
+                lambda x: x.product_id == self.product_id
+            )
+            # agrego las full reconciliaciones
+            to_reconciled_line_ids.append(product_move_line_ids.full_reconcile_id.reconciled_line_ids)
+            move_ids = product_move_line_ids.mapped("move_id")
+            move_ids.button_draft()
+            for move_line in product_move_line_ids:
+                multiplier = 1 if move_line.credit == 0 else -1
+                field = "debit" if move_line.credit == 0 else "credit"
+                # OJO el valor de currency puede ser positivo o negativo
+                # pero en el asiento siempre es positivo para debit y negativo para credit
+                # por eso multiplico el valor absoluto por el signo
+                lines.append(
+                    Command.update(
+                        move_line.id,
+                        {
+                            "amount_currency": abs(line_id.new_value_in_currency) * multiplier,
+                            field: abs(line_id.new_value),
+                        },
+                    )
+                )
+            if lines:
+                line_id.layer_id.account_move_id.line_ids = lines
+            move_ids.action_post()
+
+        product_id = self.product_id.with_company(self.company_id.id)
+        if product_id.standard_price_in_currency != self.final_amount_in_currency:
+            product_id.with_context(disable_auto_svl=True).sudo().write(
+                {"standard_price_in_currency": self.final_amount_in_currency}
+            )
+            self.amount_changed = True
+        if product_id.standard_price != self.final_amount:
+            product_id.with_context(disable_auto_svl=True).sudo().write({"standard_price": self.final_amount})
+            self.amount_changed = True
+
+        self.slv_changed = slv_changed
+        for to_reconciled_lines in to_reconciled_line_ids:
+            # si no tiene reconciliaciones, lo reconcilio sino supongo
+            # que ya lo reconcilie antes
+            if not any(to_reconciled_lines.mapped("reconciled")):
+                to_reconciled_lines.reconcile()
+        self.state = "done"
+
+
+class StockValuationLayerRecomputeLine(models.Model):
+    _name = "stock.valuation.layer.recompute.line"
+    _description = "lines layer recompute"
+
+    layer_id = fields.Many2one("stock.valuation.layer")
+    quantity = fields.Float(related="layer_id.quantity")
+    quantity_at_time = fields.Float()
+    layer_date = fields.Datetime(related="layer_id.create_date", string="Layer Date")
+    recompute_id = fields.Many2one("stock.valuation.layer.recompute")
+    currency_id = fields.Many2one("res.currency", related="recompute_id.valuation_currency_id")
+    company_currency_id = fields.Many2one("res.currency", related="recompute_id.currency_id")
+
+    # company currency
+    layer_unit_cost = fields.Monetary(currency_field="company_currency_id")
+    layer_value = fields.Monetary(currency_field="company_currency_id")
+    new_unit_cost = fields.Monetary(currency_field="company_currency_id")
+    new_value = fields.Monetary(currency_field="company_currency_id")
+    standard_price = fields.Monetary(currency_field="company_currency_id")
+
+    # Secundary currency
+    layer_unit_cost_in_currency = fields.Monetary()
+    layer_value_in_currency = fields.Monetary()
+    new_unit_cost_in_currency = fields.Monetary()
+    new_value_in_currency = fields.Monetary()
+    standard_price_in_currency = fields.Monetary()
+    need_changes = fields.Boolean()
+    svl_type = fields.Char()

--- a/stock_currency_valuation_recompute/security/ir.model.access.csv
+++ b/stock_currency_valuation_recompute/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_valuation_layer_recompute,access_stock_valuation_layer_recompute,model_stock_valuation_layer_recompute,stock.group_stock_manager,1,1,1,1
+access_stock_valuation_layer_recompute_line,access_stock_valuation_layer_recompute_line,model_stock_valuation_layer_recompute_line,stock.group_stock_manager,1,1,1,1

--- a/stock_currency_valuation_recompute/tests/__init__.py
+++ b/stock_currency_valuation_recompute/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_layer_recompute

--- a/stock_currency_valuation_recompute/tests/test_layer_recompute.py
+++ b/stock_currency_valuation_recompute/tests/test_layer_recompute.py
@@ -1,0 +1,93 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestLayerRecompute(TransactionCase):
+    def test_recompute_detects_out_valued_with_stale_cost(self):
+        """Una salida valuada con el costo en moneda desactualizado tiene que salir marcada."""
+        company = self.env.company
+        categ = self.env["product.category"].create(
+            {
+                "name": "Categoria valuada en moneda",
+                "property_cost_method": "average",
+                "property_valuation": "manual_periodic",
+                "valuation_currency_id": self.env.ref("base.USD").id,
+            }
+        )
+        product = (
+            self.env["product.product"]
+            .create({"name": "Producto valuado en moneda", "is_storable": True, "categ_id": categ.id})
+            .with_company(company)
+        )
+        product.standard_price = 1000.0
+        product.standard_price_in_currency = 10.0
+
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", company.id)], limit=1)
+        quant = self.env["stock.quant"].with_context(inventory_mode=True)
+        # ingreso 10 unidades
+        quant.create(
+            {
+                "product_id": product.id,
+                "location_id": warehouse.lot_stock_id.id,
+                "inventory_quantity": 10.0,
+            }
+        ).action_apply_inventory()
+
+        # revaluacion que en 18.0 no impactaba la ficha: el layer queda en 50 USD
+        # pero el costo en moneda del producto sigue en 10
+        revaluation_layer = self.env["stock.valuation.layer"].create(
+            {
+                "company_id": company.id,
+                "product_id": product.id,
+                "description": "Manual Stock Valuation: test.",
+                "value": 5000.0,
+                "value_in_currency": 50.0,
+                "quantity": 0,
+            }
+        )
+
+        # salida de 2 unidades, valuada con el costo en moneda desactualizado
+        quant.search([("product_id", "=", product.id), ("location_id", "=", warehouse.lot_stock_id.id)]).write(
+            {"inventory_quantity": 8.0}
+        )
+        quant.search(
+            [("product_id", "=", product.id), ("location_id", "=", warehouse.lot_stock_id.id)]
+        ).action_apply_inventory()
+
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": company.id, "product_id": product.id}
+        )
+        recompute.action_compute_lines()
+
+        self.assertEqual(recompute.state, "in_process", "Tiene que haber detectado diferencias")
+        self.assertTrue(recompute.line_ids, "Tiene que armar una linea por layer")
+        self.assertAlmostEqual(recompute.initial_amount_in_currency, 10.0, places=2)
+        # el recalculo reparte los 50 USD de la revaluacion sobre las 10 unidades
+        self.assertAlmostEqual(recompute.final_amount_in_currency, 15.0, places=2)
+        self.assertTrue(
+            recompute.line_ids.filtered("need_changes"),
+            "La salida valuada con el costo viejo tiene que quedar marcada para ajustar",
+        )
+        # el ajuste manual y todo lo anterior se respeta: solo se toca lo posterior
+        adjustment = recompute.line_ids.filtered(lambda x: x.layer_id == revaluation_layer)
+        self.assertTrue(adjustment, "El ajuste manual tiene que aparecer como linea")
+        self.assertFalse(adjustment.need_changes, "El ajuste manual no se toca")
+        self.assertEqual(
+            recompute.last_manual_svl_id,
+            revaluation_layer,
+            "Tiene que detectar el ajuste manual sin importar quien lo cargo",
+        )
+        for line in recompute.line_ids.filtered("need_changes"):
+            self.assertGreater(
+                line.layer_id.id, revaluation_layer.id, "Solo se marcan layers posteriores al ajuste manual"
+            )
+
+        # los layers que no se van a escribir avanzan el promedio con su valor registrado,
+        # para que el costo final cierre contra lo que efectivamente queda en la base
+        for line in recompute.line_ids.filtered(lambda x: not x.need_changes):
+            self.assertEqual(
+                line.new_value_in_currency,
+                line.layer_value_in_currency,
+                "Un layer que no se escribe no puede aportar al promedio un valor distinto al registrado",
+            )
+            self.assertEqual(line.new_value, line.layer_value)

--- a/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
+++ b/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_valuation_layer_recompute_form_view" model="ir.ui.view">
+        <field name="name">stock.valuation.layer.recompute.form</field>
+        <field name="model">stock.valuation.layer.recompute</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_compute_lines" type="object" string="Compute lines" invisible="state in ['done', 'cancel']"/>
+                    <button name="action_manual_slv_revaluation" type="object" string="Revaluate" class="btn-primary" invisible="state in ['draft', 'cancel', 'done']"/>
+                    <button name="action_cancel" type="object" string="Cancel" invisible="state in ['done', 'cancel']"/>
+                    <button name="back_to_draft" type="object" string="Back to Draft" invisible="state != 'cancel'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,in_process,done,cancel"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group colspan="2">
+                            <field name="company_id" readonly="state != 'draft'"/>
+                            <field name="product_id" readonly="state != 'draft'"/>
+                            <field name="valuation_currency_id" readonly="state in ['done', 'cancel']"/>
+                        </group>
+                        <group>
+                            <field name="initial_amount" readonly="state in ['done', 'cancel']"/>
+                            <field name="final_amount" readonly="state in ['done', 'cancel']"/>
+                            <field name="final_rate" readonly="1"/>
+                        </group>
+                        <group>
+                            <field name="initial_amount_in_currency" readonly="state in ['done', 'cancel']"/>
+                            <field name="final_amount_in_currency" readonly="state in ['done', 'cancel']"/>
+                        </group>
+                        <field name="last_manual_svl_id" readonly="1"/>
+                    </group>
+                    <field name="line_ids" readonly="state in ['done', 'cancel']">
+                        <list>
+                            <field name="currency_id" column_invisible="True"/>
+                            <field name="company_currency_id" column_invisible="True"/>
+                            <field name="layer_date" readonly="1" optional="hide"/>
+                            <field name="svl_type" readonly="1" optional="hide"/>
+                            <field name="layer_id" readonly="1" optional="show"/>
+                            <field name="quantity" readonly="1" optional="hide"/>
+                            <field name="quantity_at_time" readonly="1" optional="hide"/>
+                            <field name="layer_unit_cost" optional="hide"/>
+                            <field name="layer_value" currency_field="company_currency_id"/>
+                            <field name="new_unit_cost" currency_field="company_currency_id" optional="hide"/>
+                            <field name="new_value" currency_field="company_currency_id"/>
+                            <field name="layer_unit_cost_in_currency" optional="hide"/>
+                            <field name="layer_value_in_currency"/>
+                            <field name="new_unit_cost_in_currency" optional="hide"/>
+                            <field name="new_value_in_currency"/>
+                            <field name="standard_price" currency_field="company_currency_id"/>
+                            <field name="standard_price_in_currency"/>
+                            <field name="need_changes" readonly="1"/>
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="stock_valuation_layer_recompute_list_view" model="ir.ui.view">
+        <field name="name">stock.valuation.layer.recompute.list</field>
+        <field name="model">stock.valuation.layer.recompute</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="product_id"/>
+                <field name="valuation_currency_id"/>
+                <field name="amount_changed"/>
+                <field name="slv_changed"/>
+                <field name="initial_amount"/>
+                <field name="final_amount"/>
+                <field name="initial_amount_in_currency"/>
+                <field name="final_amount_in_currency"/>
+                <field name="state"/>
+                <field name="last_manual_svl_id"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="stock_valuation_layer_recompute_search_view" model="ir.ui.view">
+        <field name="name">stock.valuation.layer.recompute.search</field>
+        <field name="model">stock.valuation.layer.recompute</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter string="Draft" name="filter_draft" domain="[('state', '=', 'draft')]"/>
+                <filter string="In Process" name="filter_in_process" domain="[('state', '=', 'in_process')]"/>
+                <filter string="Done" name="filter_done" domain="[('state', '=', 'done')]"/>
+                <filter string="Cancelled" name="filter_cancel" domain="[('state', '=', 'cancel')]"/>
+                <filter string="SLV Changed" name="filter_slv_changed" domain="[('slv_changed', '=', True)]"/>
+                <field name="product_id" string="Product"/>
+                <group expand="0" name="group_by" string="Group By">
+                    <filter string="Product" name="group_by_product_id" context="{'group_by': 'product_id'}"/>
+                    <filter string="Company" name="group_by_company_id" context="{'group_by': 'company_id'}"/>
+                    <filter string="State" name="group_by_state" context="{'group_by': 'state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_stock_valuation_layer_recompute" model="ir.actions.act_window">
+        <field name="name">Recompute layer</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.valuation.layer.recompute</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem action="action_stock_valuation_layer_recompute" id="layer_recompute_menu" parent="stock.menu_warehouse_report" name="Layer recompute" sequence="2"/>
+
+</odoo>


### PR DESCRIPTION
> **Standalone module, not meant to be merged into the base module's behaviour.**
> It is installed on an affected database, run once per product, and uninstalled
> afterwards. It adds nothing to `stock_currency_valuation` while installed — that
> module is untouched by this PR. The permanent fix is #993.

Port of #736 (16.0, never merged) to 18.0, packaged as its own module.

## Why the wizard fix is not enough

#993 makes the revaluation write `standard_price_in_currency` again. That stops the
bleeding, but it does not repair a database that already ran revaluations while the
field was not being written.

The error propagated. Out moves are valued as `standard_price_in_currency * quantity`,
so every sale after a missed revaluation left with the stale cost. Inbound moves then
re-averaged on top of it. The product form, the layers and the journal entries all end
up inconsistent, and simply setting the cost on the product does not fix the history:
by the time you correct it, quantities and averages have moved on.

## What it adds

`stock.valuation.layer.recompute`: pick a product and a company, and it replays the
whole valuation history in chronological order, computing what each layer should have
been. Layer types are handled separately — purchase (honouring the PO currency and the
manual rate), purchase refund, landed cost, inventory, out, return and manual
adjustment.

The result is shown line by line, old value next to new value, with a `need_changes`
flag, and nothing is written until `Revaluate` is pressed. That step writes the
corrected `unit_cost` / `value` / `unit_cost_in_currency` / `value_in_currency` back to
each layer, redrafts and reposts the related journal entries with the corrected
`amount_currency` and `debit`/`credit`, restores the reconciliations, and finally sets
the recomputed cost on the product.

`delete_adjust_compute_lines` removes previously applied manual adjustment layers with
their journal entries before recomputing, so a run can be redone from a clean state.

Menu: Inventory / Reporting / Layer recompute.

## Porting notes

- `attrs` is gone in 18.0: the view uses direct `invisible` / `readonly`.
- `tree` became `list`.
- The `header` was outside `form` in the original arch, which no longer validates.
- The ACL is restricted to `stock.group_stock_manager` rather than `base.group_user`,
  since the tool rewrites posted entries.
- 18.0 added lot level valuation. This works at product level, so
  `_check_supported_product` raises on `lot_valuated` products instead of silently
  producing wrong costs.
- Dropped the dead `patch_check_reconciliation` helper and the commented out branch for
  layers older than #675.

## Test plan

```
odoo -d <db> -i stock_currency_valuation_recompute --test-enable --test-tags=/stock_currency_valuation_recompute
```

`test_recompute_detects_out_valued_with_stale_cost` builds the scenario: stock in, a
revaluation layer worth 50 in the secondary currency that never reached the product,
and an out valued with the stale cost. It asserts the tool reports the product cost
going from 10 to 15 and flags the affected layers.

## Worth a careful look

- **It rewrites posted journal entries** (`button_draft` → edit lines → `action_post`)
  and re-reconciles. That is the point of the tool, but it is the risky part and the
  reason for the manager-only ACL and the two step confirm. This path is not covered by
  the test.
- **`remaining_qty` / `remaining_value` are not touched**, same as the original. Worth
  deciding before running this on FIFO products.
- Layers with a landed cost raise on write rather than being adjusted.