### PR TITLE
[I18N] stock_delivery_zone: translate es.po to Spanish

### DIFF
--- a/stock_delivery_zone/i18n/es.po
+++ b/stock_delivery_zone/i18n/es.po
@@ -19,71 +19,71 @@ msgstr ""
 #. module: stock_delivery_zone
 #: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_picking_ux
 msgid "<strong>Zone:</strong>"
-msgstr ""
+msgstr "<strong>Zona:</strong>"
 
 #. module: stock_delivery_zone
 #: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_report_delivery_document
 msgid "<strong>Zone</strong>"
-msgstr ""
+msgstr "<strong>Zona</strong>"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__active
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #. module: stock_delivery_zone
 #: model:ir.model,name:stock_delivery_zone.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Contacto"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__create_date
 msgid "Created on"
-msgstr ""
+msgstr "Fecha de creación"
 
 #. module: stock_delivery_zone
 #: model:ir.model,name:stock_delivery_zone.model_stock_delivery_zone
 msgid "Delivery Zone"
-msgstr ""
+msgstr "Zona de entrega"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__display_name
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__display_name
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nombre mostrado"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__id
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__id
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización por"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Última actualización"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_delivery_zone__name
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: stock_delivery_zone
 #: model:ir.model,name:stock_delivery_zone.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Transferencia"
 
 #. module: stock_delivery_zone
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_res_partner__delivery_zone_id
@@ -91,11 +91,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_delivery_zone.field_stock_picking__delivery_zone_id
 #: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_form
 msgid "Zone"
-msgstr ""
+msgstr "Zona"
 
 #. module: stock_delivery_zone
 #: model:ir.actions.act_window,name:stock_delivery_zone.stock_delivery_zone_action_stock_delivery_zone
 #: model:ir.ui.menu,name:stock_delivery_zone.stock_delivery_zone_menu_stock_delivery_zone
 #: model_terms:ir.ui.view,arch_db:stock_delivery_zone.stock_delivery_zone_view_stock_delivery_zone_list
 msgid "Zones"
-msgstr ""
+msgstr "Zonas"


### PR DESCRIPTION
### What

The `es.po` of `stock_delivery_zone` on `19.0` was the freshly generated
template (POT 2026-06-02) with every `msgstr` empty. On a Spanish database
the module rendered in English:

- `Zone` field on the contact and the picking → **Zona**
- Contacts → Configuration menu `Zones` → **Zonas**
- Model `Delivery Zone` → **Zona de entrega**
- Report literals `<strong>Zone:</strong>` / `<strong>Zone</strong>` — these
  are **printed** on the delivery slip and the picking operations, so the
  label reached the carrier in English.

### Why

The translation was done in the 18.0 backport (#945) and never made it back
to 19.0. The 18.0 `es.po` already has all the correct `msgstr`.

### Change

Copy the `msgstr` from the 18.0 `es.po` into the 19.0 one. Same `msgid`s,
same POT — a single translation file. No code or views touched. Only `es.po`
is needed (not `es_419.po`): es_419 databases load it as the base-language
fallback.

### Test plan

- Install/update the module on an `es` database and confirm the field, the
  menu, the model name and the printed report labels render in Spanish.
- Note for the rollout: on 19.0 databases where the module is already
  installed the terms don't update on their own — the module has to be
  upgraded to reload the translations.

Task: https://www.adhoc.inc/odoo/project.task/72426
