### PR TITLE
[FIX] stock_voucher_ux: number autoprinted vouchers on every validation

### DIFF
--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -151,7 +151,14 @@ class ReportController(report.ReportController):
                             pass
 
                 elif book_id and picking_id:
+                    # Autoimpreso impreso por fuera de ``do_print_voucher`` (menú
+                    # nativo): se numera y re-renderiza, como las otras dos ramas.
                     if not picking.voucher_ids and book_id:
                         picking.assign_numbers(1, book_id)
+                        picking.env.flush_all()
+                        try:
+                            response = super().report_download(data, context=context, token=token, **kwargs)
+                        except Exception:
+                            pass
 
         return response

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -27,13 +27,39 @@ class StockPicking(models.Model):
     @api.depends("voucher_ids")
     def _compute_with_vouchers(self):
         for rec in self:
-            rec.with_vouchers = bool(self.voucher_ids)
+            rec.with_vouchers = bool(rec.voucher_ids)
 
     def do_print_voucher(self):
+        # El autoimpreso se numera antes del render: el reporte imprime
+        # ``o.vouchers or o.name``. El preimpreso, por páginas reales al imprimir.
+        if self.autoprinted and not self.voucher_ids:
+            self.assign_numbers(1, self.book_id)
         self.printed = True
         if self.book_id:
             self.book_id = self.book_id.id
         return super(StockPicking, self).do_print_voucher()
+
+    def assign_numbers(self, estimated_number_of_pages, book):
+        # Único punto por el que pasan todos los caminos de numeración.
+        self._check_voucher_cai_range(book, estimated_number_of_pages)
+        return super().assign_numbers(estimated_number_of_pages, book)
+
+    def _check_voucher_cai_range(self, book, estimated_number_of_pages):
+        """No numerar por encima del tope del CAI (``sequence_to``)."""
+        sequence_to = (book.sequence_to or "").strip()
+        if not book.autoprinted or not sequence_to.isdigit():
+            return
+        # ``number_next_actual`` no declara depends y la secuencia se consume con
+        # SQL crudo: sin invalidar, el segundo remito de la transacción lee viejo.
+        book.sequence_id.invalidate_recordset(["number_next_actual"])
+        last_number = book.sequence_id.number_next_actual + estimated_number_of_pages - 1
+        if last_number > int(sequence_to):
+            raise UserError(
+                _(
+                    "The voucher number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range.",
+                    last_number,
+                )
+            )
 
     def do_print_and_assign(self):
         if not self.book_id and self.picking_type_code != "incoming":
@@ -48,13 +74,9 @@ class StockPicking(models.Model):
             self.printed = True
             return self.with_context(assign=True).do_print_voucher()
         else:
-            if self.book_id.sequence_to and int(self.next_voucher_number) > int(self.book_id.sequence_to):
-                raise UserError(
-                    _(
-                        "The voucher number %s exceeds the range specified in the CAI. Please update the range or use a different CAI with a different range.",
-                        self.next_voucher_number,
-                    )
-                )
+            if self.voucher_ids:
+                # El botón sigue clickeable después de imprimir: no renumerar.
+                return self.do_print_voucher()
             self.assign_numbers(1, self.book_id)
             return self.do_print_voucher()
 
@@ -77,22 +99,13 @@ class StockPicking(models.Model):
         return res
 
     def _action_done(self):
-        # Los talonarios preimpresos (``autoprinted=False``) se numeran al
-        # IMPRIMIR según las páginas reales del reporte, no en la validación por
-        # la estimación ``lines_per_voucher``. Los autoimpresos se numeran acá al
-        # validar, pero sólo si el tipo de operación pide imprimir el remito al
-        # validar (``auto_print_delivery_slip``) — el remito reemplaza al recibo
-        # de entrega nativo. Sin ese flag el número se asigna al IMPRIMIR a mano.
+        # Autoimpreso: un remito de N hojas, un solo número, acá. Preimpreso: al
+        # imprimir, tantos como hojas reales tenga el PDF.
         res = super(StockPicking, self.with_context(do_not_assign_numbers=True))._action_done()
         if self._context.get("do_not_assign_numbers"):
             return res
-        for picking in self.filtered(
-            lambda p: p.book_required
-            and p.book_id
-            and p.book_id.autoprinted
-            and p.picking_type_id.auto_print_delivery_slip
-        ):
-            picking.assign_numbers(picking.get_estimated_number_of_pages(), picking.book_id)
+        for picking in self.filtered(lambda p: p.book_required and p.book_id and p.book_id.autoprinted):
+            picking.assign_numbers(1, picking.book_id)
         return res
 
     def clean_voucher_data(self):

--- a/stock_voucher_ux/tests/test_remito_preimpreso.py
+++ b/stock_voucher_ux/tests/test_remito_preimpreso.py
@@ -2,21 +2,12 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
-class TestRemitoPreimpresoNumbering(TransactionCase):
-    """Numeración de remitos según el tipo de talonario.
-
-    Preimpreso (``autoprinted=False``): NO se numera en la validación por la
-    estimación ``lines_per_voucher`` (subnumera). La cantidad se determina al
-    imprimir, según las páginas reales del reporte (controller).
-
-    Autoimpreso (``autoprinted=True``): se numera en la validación sólo si el
-    tipo de operación pide imprimir el remito al validar
-    (``auto_print_delivery_slip``) — el remito reemplaza al recibo de entrega
-    nativo. Sin ese flag no se numera al validar (se asigna al imprimir a mano).
-    """
+class TestRemitoNumbering(TransactionCase):
+    """Cuándo y cuántos números de remito se asignan según el talonario."""
 
     @classmethod
     def setUpClass(cls):
@@ -42,30 +33,32 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
             {
                 "name": "Autoimpreso test",
                 "sequence_id": cls.sequence.id,
-                "lines_per_voucher": 0,
+                "lines_per_voucher": 2,
                 "autoprinted": True,
             }
         )
-        # Consumible no almacenable: la validación no requiere stock disponible.
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "Producto remito test",
-                "type": "consu",
-            }
-        )
+        # Consumible: la validación no requiere stock disponible.
+        cls.product = cls.env["product.product"].create({"name": "Producto remito test", "type": "consu"})
         cls.src = cls.env.ref("stock.stock_location_stock")
         cls.dest = cls.env.ref("stock.stock_location_customers")
 
-    def _make_done_picking(self, book, auto_print=False):
+    def _make_done_picking(self, book, book_required=True, nlines=1):
         picking_type = self.env.ref("stock.picking_type_out")
         picking_type.write(
             {
-                "book_required": True,
+                "book_required": book_required,
                 "book_id": book.id,
                 "voucher_required": False,
-                "auto_print_delivery_slip": auto_print,
+                # Gobierna la impresión, no la numeración.
+                "auto_print_delivery_slip": False,
             }
         )
+        # Productos distintos: los del mismo producto se agrupan en una línea.
+        products = self.product
+        if nlines > 1:
+            products |= self.env["product.product"].create(
+                [{"name": "Producto remito test %s" % index, "type": "consu"} for index in range(1, nlines)]
+            )
         picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": picking_type.id,
@@ -77,14 +70,15 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
                         0,
                         0,
                         {
-                            "name": self.product.name,
-                            "product_id": self.product.id,
+                            "name": product.name,
+                            "product_id": product.id,
                             "product_uom_qty": 1.0,
-                            "product_uom": self.product.uom_id.id,
+                            "product_uom": product.uom_id.id,
                             "location_id": self.src.id,
                             "location_dest_id": self.dest.id,
                         },
                     )
+                    for product in products
                 ],
             }
         )
@@ -94,33 +88,48 @@ class TestRemitoPreimpresoNumbering(TransactionCase):
         picking.with_context(skip_sms=True).button_validate()
         return picking
 
-    def test_preprinted_not_preassigned_on_validation(self):
+    def test_preprinted_not_numbered_on_validation(self):
         picking = self._make_done_picking(self.book_pre)
         self.assertEqual(picking.state, "done")
-        self.assertFalse(
-            picking.voucher_ids,
-            "Un talonario preimpreso no debe pre-numerarse por estimación en _action_done; "
-            "la numeración se hace al imprimir según páginas reales.",
-        )
+        self.assertFalse(picking.voucher_ids, "El preimpreso se numera al imprimir, por páginas reales.")
 
-    def test_autoprinted_assigned_on_validation_with_flag(self):
-        # Con auto_print_delivery_slip el remito reemplaza al recibo de entrega
-        # y el autoimpreso se numera al validar.
-        picking = self._make_done_picking(self.book_auto, auto_print=True)
+    def test_autoprinted_numbered_on_validation(self):
+        # 3 líneas con 2 por remito estimarían 2: el autoimpreso lleva uno solo.
+        picking = self._make_done_picking(self.book_auto, nlines=3)
         self.assertEqual(picking.state, "done")
-        self.assertEqual(
-            len(picking.voucher_ids),
-            1,
-            "Un talonario autoimpreso debe asignar un único remito en la validación "
-            "cuando el tipo de operación tiene auto_print_delivery_slip.",
-        )
+        self.assertEqual(len(picking.voucher_ids), 1)
 
-    def test_autoprinted_not_assigned_without_flag(self):
-        # Sin el flag, validar no numera: el número se asigna al imprimir a mano.
-        picking = self._make_done_picking(self.book_auto, auto_print=False)
-        self.assertEqual(picking.state, "done")
-        self.assertFalse(
-            picking.voucher_ids,
-            "Sin auto_print_delivery_slip, un talonario autoimpreso no debe numerarse "
-            "en la validación; el número se asigna al imprimir.",
+    def test_print_numbers_the_autoprinted_book(self):
+        picking = self._make_done_picking(self.book_auto, book_required=False)
+        picking.do_print_voucher()
+        self.assertEqual(len(picking.voucher_ids), 1)
+
+    def test_print_and_assign_does_not_renumber(self):
+        picking = self._make_done_picking(self.book_auto)
+        picking.do_print_and_assign()
+        picking.do_print_and_assign()
+        self.assertEqual(len(picking.voucher_ids), 1)
+
+    def test_cai_range_is_inclusive_and_blocks_past_the_top(self):
+        sequence = self.env["ir.sequence"].create(
+            {
+                "name": "Test stock voucher CAI",
+                "code": "stock.voucher",
+                "prefix": "0002-",
+                "padding": 8,
+                "implementation": "no_gap",
+                "number_next": 100,
+            }
         )
+        book = self.env["stock.book"].create(
+            {
+                "name": "Autoimpreso con tope de CAI",
+                "sequence_id": sequence.id,
+                "lines_per_voucher": 0,
+                "autoprinted": True,
+                "sequence_to": "00000100",
+            }
+        )
+        self.assertEqual(len(self._make_done_picking(book).voucher_ids), 1)
+        with self.assertRaises(UserError):
+            self._make_done_picking(book)


### PR DESCRIPTION
Regression from #975.

Numbering an autoprinted voucher book on validation was gated behind the operation type's `auto_print_delivery_slip`. That flag is off by default and nobody had it on, so those pickings started being validated with **no voucher number at all**:

- the number is only assigned later, when someone presses *Print Vouchers* — which also downloads the PDF on every single validation;
- a delivery slip printed before that comes out identified by the picking name (e.g. `WH/PACK/00410`) instead of the voucher number, because both `print_report_name` and the report's own number (`o.vouchers or o.name`) fall back to the picking name when the picking has no vouchers.

The flag governs **printing**, not numbering: it asks Odoo to print the delivery slip on validation. There is no way to configure "number on validation, print when I want", which is what these books did before #975.

## Change

`_action_done` numbers the autoprinted book again for every validation, as it did before #975. The flag is left deciding only whether `button_validate` prints, which is what #975 was actually about, and the backorder wizard override it added is untouched.

Numbering on validation is not enough on its own, so the print path is closed too. `do_print_voucher` did not number at all, and the controller numbered *after* rendering the PDF without re-rendering it — that is why the first print came out with the picking name and only the reprint carried the number. It is still reachable with an operation type that carries a voucher book without `book_required`, on batch validation, and from the native print menu, which never goes through `do_print_voucher`. An autoprinted book is now numbered before the render, and the controller branch that had no re-render numbers and re-renders like the other two.

Validation and printing become the numbering paths of every autoprinted book, so four things that only held on the *Print Vouchers* path are fixed along with it:

- The **CAI upper bound** (`sequence_to`) was checked only in `do_print_and_assign`, so numbering on validation could go past the authorized range silently. The check moves to `assign_numbers`, the single choke point of every numbering path (validation, print controller and IoT). It now covers every number the call consumes, not just the first one, and reads the sequence fresh: `number_next_actual` declares no `depends` and the sequence is consumed with raw SQL, so the cached value is stale as soon as a second voucher is numbered in the same transaction.
- **An autoprinted book takes exactly one number**, as its own field documents (*"Otherwise, it will assign only one voucher"*): we print the document, so a long transfer is one voucher spanning several pages and the report already paginates them. Validation was instead taking one number per **estimated** page — how the base module behaved before autoprinted books existed — while the print button took one. No path in this module estimates a voucher count any more; the only exact count, the real pages of the rendered PDF, is what pre-printed books already use.
- `do_print_and_assign` was **not idempotent**: returning a report action does not reload the form, so the button stayed clickable and a second click burned another number. It now reprints without renumbering.
- `_compute_with_vouchers` read `voucher_ids` from the whole recordset instead of from each record, hiding the *Print Vouchers* button on pickings without a number whenever several were read at once.

Pre-printed books (`autoprinted=False`) are unchanged throughout: still numbered on print, one per real page of the rendered PDF.

## Test plan

`stock_voucher_ux/tests/test_remito_preimpreso.py` — 5 tests covering when and how many numbers each kind of book gets: on validation, on *Print Vouchers*, on *Print*, on a reprint, and against the CAI top.

- 5/5 pass.
- Reverting the gate removal in `_action_done` fails `test_autoprinted_numbered_on_validation` and `test_cai_range_is_inclusive_and_blocks_past_the_top`.
- Restoring the estimate in `_action_done` fails `test_autoprinted_numbered_on_validation` (`2 != 1`): the picking has 3 lines on a book of 2 lines per voucher, so an estimate would take 2 numbers.
- Reverting the `do_print_voucher` change fails exactly `test_print_numbers_the_autoprinted_book` (`0 != 1`).

`stock_batch_picking_ux` still numbers by estimate on batch validation; that module is #986.

Tickets https://www.adhoc.inc/odoo/helpdesk.ticket/125112 and https://www.adhoc.inc/odoo/helpdesk.ticket/125176
