### PR TITLE
[FIX] stock_ux: return in the delivered move UoM on "Return All"

### DIFF
--- a/stock_ux/models/stock_return_picking.py
+++ b/stock_ux/models/stock_return_picking.py
@@ -15,3 +15,30 @@ class StockReturnPicking(models.TransientModel):
         picking = super()._create_return()
         picking.write({"note": self.reason})
         return picking
+
+    def action_create_returns_all(self):
+        # "Devolver todo" debe dejar la devolución en la UdM del movimiento que
+        # revierte (como la 19), no en la UdM de referencia del producto. El
+        # cálculo de cantidades y el redondeo los sigue haciendo el core; acá solo
+        # pasamos un flag de contexto para que `_prepare_move_default_values`
+        # herede la UdM del movimiento. Ese cambio aplica únicamente cuando la
+        # entrega quedó en una UdM distinta a la de referencia (p.ej. con
+        # "Propagar UdM" activo); el "Devolver" manual y las devoluciones sin
+        # diferencia de UdM corren el core intacto. Ver ticket 125517.
+        return super(StockReturnPicking, self.with_context(return_all_move_uom=True)).action_create_returns_all()
+
+
+class StockReturnPickingLine(models.TransientModel):
+    _inherit = "stock.return.picking.line"
+
+    def _prepare_move_default_values(self, new_picking):
+        vals = super()._prepare_move_default_values(new_picking)
+        # Solo cuando "Devolver todo" lo pide (contexto) y solo si la entrega está
+        # en una UdM distinta a la de referencia: el movimiento de devolución
+        # hereda la UdM del movimiento original en vez de forzar la de referencia.
+        # Fuera de ese caso (Devolver manual, o sin diferencia de UdM) se respeta
+        # el comportamiento del core. Ver ticket 125517.
+        move = self.move_id
+        if self.env.context.get("return_all_move_uom") and move and move.product_uom != self.product_id.uom_id:
+            vals["product_uom"] = move.product_uom.id
+        return vals

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_mto_warehouse_propagation
 from . import test_stock_orderpoint_multiple_over_max
+from . import test_return_all_uom

--- a/stock_ux/tests/test_return_all_uom.py
+++ b/stock_ux/tests/test_return_all_uom.py
@@ -1,0 +1,104 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReturnAllUom(TransactionCase):
+    """ "Devolver todo" debe devolver en la UdM del movimiento entregado.
+
+    Backport del comportamiento de la 19: cuando la entrega está en una UdM
+    distinta a la de referencia del producto (p.ej. con `stock.propagate_uom`
+    activo, que deja las entregas en la UdM de la línea), la devolución hereda la
+    UdM del movimiento y devuelve exactamente lo entregado, sin convertir a la UdM
+    de referencia (que dejaba el remito en otra unidad y redondeaba de más). Ver
+    ticket 125517.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_dozen = cls.env.ref("uom.product_uom_dozen")
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
+
+    def _deliver(self, product, uom, qty):
+        """Confirma y valida una entrega de `qty` en `uom`, devuelve el picking hecho."""
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_out.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom": uom.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                        },
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        move = picking.move_ids
+        move.quantity = qty
+        move.picked = True
+        picking._action_done()
+        self.assertEqual(move.state, "done")
+        self.assertEqual(move.product_uom, uom)
+        return picking
+
+    def _return_all(self, picking):
+        wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_id=picking.id, active_ids=picking.ids, active_model="stock.picking")
+            .create({})
+        )
+        action = wizard.action_create_returns_all()
+        return self.env["stock.picking"].browse(action["res_id"]).move_ids
+
+    def test_return_all_keeps_move_uom(self):
+        """Entrega en Unidades de un producto con referencia en Docenas -> la
+        devolución queda en Unidades (misma UdM que la entrega), no en Docenas.
+
+        Sin el fix el core copiaba el número crudo (24) interpretándolo en la UdM
+        de referencia, así que salían 24 Docenas.
+        """
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto con referencia en docenas",
+                "is_storable": True,
+                "uom_id": self.uom_dozen.id,
+                "uom_po_id": self.uom_dozen.id,
+            }
+        )
+        picking = self._deliver(product, self.uom_unit, 24)
+        return_move = self._return_all(picking)
+        self.assertEqual(return_move.product_uom, self.uom_unit)
+        self.assertEqual(return_move.product_uom_qty, 24.0)
+
+    def test_return_all_no_overreturn_on_non_exact_ratio(self):
+        """Ratio no exacto: devolver 1 Unidad de un producto con referencia en
+        Docenas no debe devolver de más.
+
+        Convertir a Docenas redondeaba 1/12 hacia arriba (0,09 Docenas = 1,08
+        Unidades). Heredando la UdM del movimiento la devolución es 1 Unidad exacta.
+        """
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto docenas ratio no exacto",
+                "is_storable": True,
+                "uom_id": self.uom_dozen.id,
+                "uom_po_id": self.uom_dozen.id,
+            }
+        )
+        picking = self._deliver(product, self.uom_unit, 1)
+        return_move = self._return_all(picking)
+        self.assertEqual(return_move.product_uom, self.uom_unit)
+        self.assertEqual(return_move.product_uom_qty, 1.0)


### PR DESCRIPTION
The core **Return All** button (`action_create_returns_all` on `stock.return.picking`) copies the delivered quantity straight into the return line without a UoM conversion.

`stock.move.quantity` is expressed in the **move UoM** (`product_uom`), but on 18.0 the return line interprets it in the **product reference UoM** (`stock.return.picking.line.uom_id` is `related='product_id.uom_id'`, and `_prepare_move_default_values` creates the return move with `product_uom = product_id.uom_id`). When they differ, the return comes out with the raw, unconverted number in the reference UoM.

This surfaces when `stock.propagate_uom` is enabled: deliveries/receipts keep the sale/purchase line UoM instead of being normalized to the product reference UoM, so `move.product_uom != product_id.uom_id`. The regular **Return** button is fine because it prefills the line already in the reference UoM.

### Fix
Backport the behaviour Odoo 19 ships: make the return **inherit the UoM of the move it reverses** instead of converting to the reference UoM.

- `stock.return.picking.line.uom_id` becomes computed from `move_id.product_uom` (falling back to `product_id.uom_id`).
- `_prepare_move_default_values` creates the return move in that UoM.
- `action_create_returns_all` rounds in the move UoM and no longer converts.

Compared to converting to the reference UoM, this keeps the return document in the **same unit as the delivery** it reverts, avoids the round-up over-return on products whose reference ratio is not exact (`_compute_quantity` defaults to `rounding_method='UP'`), and does not reintroduce the bug reversed once the module is ported to 19 — where the core already does exactly this.

### Reproduce (without the fix)
1. Set system parameter `stock.propagate_uom = 1`.
2. Product with reference UoM = *Dozens*, sold/delivered in *Units*; deliver 24 Units.
3. **Return → Return All** → return comes out as **24 Dozens** instead of **24 Units**.

### Test
`test_return_all_uom.py`:
- `test_return_all_keeps_move_uom`: delivery of 24 Units of a Dozens-reference product → return is **24 Units** (same UoM as the delivery), not 24 Dozens.
- `test_return_all_no_overreturn_on_non_exact_ratio`: returning 1 Unit of a Dozens-reference product returns **exactly 1 Unit** (converting would round 1/12 up to 0.09 Dozens = 1.08 Units).

> Behaviour change: affects the return of every product operated in a UoM other than its reference. Worth validating on runbot before merge.
