### PR TITLE
[FIX] stock_ux: propagate picking destination to moves on create

### DIFF
--- a/stock_ux/models/stock_picking.py
+++ b/stock_ux/models/stock_picking.py
@@ -127,6 +127,24 @@ class StockPicking(models.Model):
                 }
             }
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Propaga el destino de la cabecera a los movimientos, como ya hace write().
+
+        El core solo lo hace en write(): si el traslado se crea con sus lineas en un
+        solo guardado, una linea puede quedar con el destino por defecto del tipo de
+        operacion en vez del que se cargo en la cabecera.
+        """
+        pickings = super().create(vals_list)
+        for picking, vals in zip(pickings, vals_list):
+            if not vals.get("location_dest_id"):
+                continue
+            moves = picking.move_ids.filtered(
+                lambda x: not x.scrapped and not x.location_final_id and x.location_dest_id != picking.location_dest_id
+            )
+            moves.write({"location_dest_id": picking.location_dest_id.id})
+        return pickings
+
     def write(self, vals):
         """
         Overrides the default write method to restrict changing the 'picking_type_id' field

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_mto_warehouse_propagation
 from . import test_stock_orderpoint_multiple_over_max
+from . import test_picking_location_dest

--- a/stock_ux/tests/test_picking_location_dest.py
+++ b/stock_ux/tests/test_picking_location_dest.py
@@ -1,0 +1,39 @@
+from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.tests import tagged
+
+
+@tagged("stock_ux_picking_location_dest")
+class TestPickingLocationDest(TestStockCommon):
+    def test_create_propagates_location_dest_to_moves(self):
+        """Una linea guardada con el destino del tipo de operacion debe tomar el de la cabecera."""
+        picking_type = self.warehouse_1.int_type_id
+        assembly = self.StockLocationObj.create(
+            {
+                "name": "Assembly",
+                "location_id": picking_type.default_location_dest_id.location_id.id,
+                "usage": "transit",
+            }
+        )
+        picking_type.default_location_dest_id = assembly
+        picking = self.PickingObj.create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": picking_type.default_location_src_id.id,
+                "location_dest_id": self.warehouse_1.lot_stock_id.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.productA.name,
+                            "product_id": self.productA.id,
+                            "product_uom_qty": 1,
+                            "location_id": picking_type.default_location_src_id.id,
+                            # el cliente web puede mandar el destino por defecto del tipo
+                            "location_dest_id": assembly.id,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(picking.move_ids.location_dest_id, self.warehouse_1.lot_stock_id)


### PR DESCRIPTION
## Qué pasa

`stock.picking.write()` propaga las ubicaciones de la cabecera a sus movimientos (bloque `after_vals`), pero `create()` no lo hace. Si el traslado se crea con sus líneas en un solo guardado (cargar la línea, cambiar el destino en la cabecera y validar sin guardar antes), un movimiento puede quedar con el **destino por defecto del tipo de operación** en vez del que se cargó en la cabecera. El resultado es silencioso: la cabecera muestra el destino correcto y el movimiento —que es el que mueve el stock— tiene otro.

En 18.0 el destino ya no se asigna a mano en el onchange como en 16.0/17.0 (`_onchange_locations`): quedó delegado a `stock.move._compute_location_dest_id`, cuyo fallback es `picking_type_id.default_location_dest_id`. Una línea creada antes de que el formulario termine de procesar el cambio de destino se guarda con ese fallback, y en un `create()` nada la corrige después.

## Fix

Override de `create()` en `stock_ux` que replica lo que ya hace `write()`: escribe el destino de la cabecera sobre los movimientos del traslado. Excluye los `scrapped` (igual que el core) y los que tienen `location_final_id`, donde el destino intermedio es legítimamente distinto (cadenas multi-paso).

## Test plan

`stock_ux/tests/test_picking_location_dest.py`: crea un traslado interno en un solo `create()`, con la línea trayendo el destino por defecto del tipo de operación, y verifica que quede con el de la cabecera.

- Con el fix: `0 failed, 0 error(s) of 6 tests` (suite completa de `stock_ux`, 18.0).
- Sin el fix: el test falla con `AssertionError` — discrimina.

El efecto en la UI se reproduce de forma determinística con throttling del navegador (~2 s de latencia), creando la línea mientras el onchange del cambio de destino está en vuelo; sin latencia la ventana es demasiado corta para verlo a mano.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125166
