### PR TITLE
[FIX] stock_ux: cancelar remanente no netea si date_deadline difiere

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "18.0.1.11.0",
+    "version": "18.0.1.12.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -99,6 +99,25 @@ class StockMove(models.Model):
             merge_into=merge_into
         )
 
+    @api.model
+    def _prepare_merge_negative_moves_excluded_distinct_fields(self):
+        # Al cancelar remanente / bajar cantidad, el core genera un movimiento
+        # negativo que debe fusionarse (netear) contra el pendiente para
+        # cancelarlo. Ese neteo usa una clave que, por defecto, incluye
+        # `date_deadline`. Si la orden se editó DESPUES de confirmar (p.ej. se
+        # agregó otra línea), Odoo le bumpea el `date_deadline` al movimiento
+        # pendiente, pero el negativo conserva el original. Al diferir, no
+        # fusionan y el negativo termina dándose vuelta como una contraentrega
+        # (ingreso fantasma `to_refund`), dejando además el pendiente huérfano.
+        # Sacamos `date_deadline` de la clave del movimiento negativo (solo bajo
+        # `cancel_from_order`, que es cuando hay una baja de cantidad) para que
+        # el neteo nativo cancele el pendiente sin importar el deadline. No toca
+        # el merge positivo↔positivo (usa la clave completa). Ver ticket 125936.
+        excluded = super()._prepare_merge_negative_moves_excluded_distinct_fields()
+        if self.env.context.get("cancel_from_order") and "date_deadline" not in excluded:
+            excluded = excluded + ["date_deadline"]
+        return excluded
+
     def action_explode(self):
         # Cuando se explota un kit, MRP cancela y elimina el move original del producto kit,
         # aunque tenga sale_line_id. Permitimos ese unlink con can_delete=True.

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_mto_warehouse_propagation
 from . import test_stock_orderpoint_multiple_over_max
+from . import test_cancel_remaining_deadline

--- a/stock_ux/tests/test_cancel_remaining_deadline.py
+++ b/stock_ux/tests/test_cancel_remaining_deadline.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "stock_ux_cancel_remaining")
+class TestCancelRemainingDeadline(TransactionCase):
+    """Ticket 125936: al cancelar remanente / bajar cantidad de un pedido que
+    se editó DESPUES de confirmar, el `date_deadline` del movimiento pendiente
+    queda desincronizado respecto del movimiento negativo de la baja. Como
+    `date_deadline` estaba en la clave de neteo, no fusionaban y el negativo se
+    daba vuelta como contraentrega (ingreso fantasma `to_refund`), dejando el
+    pendiente huérfano. Excluimos `date_deadline` de la clave del negativo bajo
+    `cancel_from_order` para que el neteo nativo cancele el pendiente.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.wh = cls.env["stock.warehouse"].create(
+            {"name": "Test 3 Steps", "code": "T3S", "delivery_steps": "pick_pack_ship"}
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Storable 125936", "type": "consu", "is_storable": True}
+        )
+        cls.env["stock.quant"]._update_available_quantity(cls.product, cls.wh.lot_stock_id, 10)
+        cls.partner = cls.env["res.partner"].create({"name": "Test Customer 125936"})
+
+    def _confirmed_so(self, qty=2):
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": self.wh.id,
+                "order_line": [(0, 0, {"product_id": self.product.id, "product_uom_qty": qty})],
+            }
+        )
+        so.action_confirm()
+        return so
+
+    def test_neg_key_excludes_date_deadline_only_under_cancel_from_order(self):
+        Move = self.env["stock.move"]
+        self.assertIn(
+            "date_deadline",
+            Move.with_context(cancel_from_order=True)._prepare_merge_negative_moves_excluded_distinct_fields(),
+        )
+        self.assertNotIn(
+            "date_deadline",
+            Move._prepare_merge_negative_moves_excluded_distinct_fields(),
+        )
+
+    def test_cancel_remaining_with_deadline_gap_nets_clean(self):
+        so = self._confirmed_so(qty=2)
+        line = so.order_line
+        # Simular edición post-confirmación: el pendiente queda con deadline posterior
+        # al del negativo que generará la baja (lo que rompía el neteo).
+        for move in line.move_ids:
+            if move.date_deadline:
+                move.date_deadline = move.date_deadline + timedelta(minutes=10)
+
+        # Bajar la cantidad (equivalente a cancelar remanente sobre lo no entregado).
+        line.with_context(skip_locked_order_line_check=True).product_uom_qty = 0
+
+        chain = self.env["stock.move"].search([("group_id", "=", so.procurement_group_id.id)])
+        orphan = chain.filtered(
+            lambda m: m.state not in ("done", "cancel") and not m.to_refund and m.product_qty > 0
+        )
+        refund = chain.filtered(lambda m: m.state not in ("done", "cancel") and m.to_refund)
+        self.assertFalse(orphan, "Quedó un movimiento pendiente huérfano tras bajar la cantidad")
+        self.assertFalse(refund, "Se generó una contraentrega / ingreso fantasma tras bajar la cantidad")


### PR DESCRIPTION
## Ticket 125936

Al **cancelar remanente / bajar la cantidad** de un pedido de venta cuyo almacén entrega en varios pasos, se generaba un **ingreso con otro tipo de operación** (contraentrega/receta fantasma) y quedaba el movimiento pendiente huérfano (el depósito preparaba de más).

## Causa raíz (reproducida)

Al bajar la cantidad, el core genera un **movimiento negativo** que debe fusionarse (netear) contra el pendiente para cancelarlo. Ese neteo usa una clave que, por defecto, incluye `date_deadline`.

Cuando el pedido se **editó después de confirmar** (p.ej. se agregó otra línea), Odoo le bumpea el `date_deadline` al movimiento pendiente, pero el negativo conserva el original. Al diferir en `date_deadline`, **no fusionan** → el negativo se da vuelta como una contraentrega (`to_refund`, ingreso desde `Customers`) y el pendiente queda huérfano.

Verificado con dato de producción (base `primicia`, OV `0001-00124487`): forward `date_deadline=16:59` vs cadena de retorno `16:49`. Reproducido A/B en base local: forzando el gap de `date_deadline` se reproduce 1:1; excluyendo `date_deadline` del neteo, cancela limpio.

## Fix

Override de `_prepare_merge_negative_moves_excluded_distinct_fields` que excluye `date_deadline` de la clave del **movimiento negativo**, **solo bajo `cancel_from_order`** (cuando hay una baja de cantidad). No toca el merge positivo↔positivo (sigue con la clave completa). Es el mismo hook nativo que Odoo provee para "decrease qty cascade on MTO".

## Tests

`stock_ux/tests/test_cancel_remaining_deadline.py`:
- El hook excluye `date_deadline` solo bajo `cancel_from_order`.
- Baja de cantidad con gap de `date_deadline` → cancela el pendiente sin contraentrega ni huérfano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)