### PR TITLE
[IMP] stock_ux: add the transfer's scheduled date on move lines

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.17.0",
+    "version": "19.0.1.18.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -33,6 +33,12 @@ class StockMoveLine(models.Model):
     origin_description = fields.Char(
         related="move_id.origin_description",
     )
+    # el scheduled_date nativo es related a move_id.date, que al validar pasa a la fecha de proceso
+    picking_scheduled_date = fields.Datetime(
+        related="picking_id.scheduled_date",
+        string="Transfer Scheduled Date",
+        help="Scheduled date of the transfer, not replaced by the processing date once done.",
+    )
 
     @api.depends_context("location")
     def _compute_product_uom_qty_location(self):

--- a/stock_ux/views/stock_move_line_views.xml
+++ b/stock_ux/views/stock_move_line_views.xml
@@ -33,6 +33,7 @@
             <filter name="by_state" position="after">
                 <filter string="Picking Partner" name="picking_partner_id"  context="{'group_by':'picking_partner_id'}"/>
                 <filter name="origin" context="{'group_by':'origin'}" string="Source"/>
+                <filter name="picking_scheduled_date" context="{'group_by':'picking_scheduled_date'}" string="Transfer Scheduled Date"/>
             </filter>
         </field>
     </record>
@@ -49,6 +50,7 @@
                      ocultamos cuando no hay ubicacion (antes daba 0,00 y confundia). -->
                 <field name="product_uom_qty_location" sum="Total"
                        column_invisible="not context.get('location', False)"/>
+                <field name="picking_scheduled_date" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Problem

`stock.move.line.scheduled_date` is related to `move_id.date`, and `stock.move.date` only holds the scheduled date **until the move is done** — `_action_done` overwrites it with the processing date, as its own help states. Moves History (Inventory > Reporting) lists done lines, so filtering, grouping or sorting by "Scheduled Date" there silently uses the effective date, and it contradicts the "Scheduled Date" of the transfer, which does survive the validation (`stock.picking._compute_scheduled_date` ignores done moves).

**Steps to reproduce**

1. Create a receipt scheduled tomorrow and validate it today.
2. Inventory > Reporting > Moves History, group by "Scheduled Date".
3. The line falls under today instead of tomorrow, while the transfer form still shows tomorrow.

## Why a new field instead of fixing the native one

I proposed changing the native field upstream in odoo/odoo#283087. Odoo declined it for 19.0 to avoid changing an existing field's value mid-version, and master then removed `stock.move.line.scheduled_date` altogether (odoo/odoo#276163, `90654e4c74e`, `date` becomes a stored related on `move_id.date`). So there is no upstream fix coming to 19.0, and overriding the native `related` here would change, in every database, the value people may already be grouping by — and it would resurrect a field that no longer exists in the next version.

Adding a separate field keeps both properties: nothing changes for the native one, and this one survives the upgrade because it is ours.

## Changes

- `picking_scheduled_date`, related to `picking_id.scheduled_date`.
- Available as a group by in the move lines search view, and as an optional (hidden by default) column of the report list.
- Lines without a transfer are empty on the new field, and keep showing whatever the native field shows.

## Version

The manifest is bumped in the PR (`19.0.1.18.0`), a new field plus view changes need the module to be updated on deploy — so this one merges with `nobump`.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/125611

