### PR TITLE
[FIX] stock_ux: import a count onto the quant it belongs to

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -40,6 +40,7 @@ Stock UX
 #. Add a "All transfers" view form in Menu: Operations
 #. Add a restriction to edit operation type for users with the "Restrict editing Operation Type in Pickings" check.
 #. Add number of packages on pickings
+#. Import an inventory count onto the stock lines that already exist: each row is matched by product, location, lot, package and owner, so the counted quantity replaces the quantity of that line instead of adding a second one to it.
 
 Installation
 ============

--- a/stock_ux/models/stock_quant.py
+++ b/stock_ux/models/stock_quant.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import api, fields, models
 
 
 class StockQuant(models.Model):
@@ -18,3 +18,141 @@ class StockQuant(models.Model):
         return self.env.context.get("inventory_mode") and self.env.user.has_group(
             "stock_ux.group_stock_inventory_adjustment"
         )
+
+    # ------------------------------------------------------------------
+    # Spreadsheet import: replace the counted quantity, never add it up
+    # ------------------------------------------------------------------
+
+    def _extract_records(self, field_paths, data, log=lambda a: None, limit=float("inf")):
+        """An empty cell in a counted quantity column is not a count of zero: half a file
+        counted is the ordinary file, and the rows left blank must stay untouched. The
+        converter turns both an empty cell and a 0 into the same 0.0, so the difference
+        can only be told here, while the rows are still the strings of the file."""
+        records = super()._extract_records(field_paths, data, log=log, limit=limit)
+        if not self.env.context.get("import_file"):
+            return records
+        return self._drop_blank_counts(records)
+
+    def _drop_blank_counts(self, records):
+        for record, extras in records:
+            for name in ("inventory_quantity", "inventory_quantity_auto_apply"):
+                if name in record and not str(record[name] or "").strip():
+                    del record[name]
+            yield record, extras
+
+    def _is_import_counting(self):
+        """Whether these rows are a count being imported by someone allowed to adjust."""
+        return bool(self.env.context.get("import_file")) and bool(
+            self.with_context(inventory_mode=True)._is_inventory_mode()
+        )
+
+    @api.model
+    def _get_import_quant_key(self, product_id, location_id, lot_id, package_id, owner_id):
+        """What identifies a stock line: two rows with this key are the same quant."""
+        return (product_id, location_id, lot_id or False, package_id or False, owner_id or False)
+
+    def _set_import_default_location(self, values):
+        """Same default location core applies while importing, needed before the lookup so
+        matching and creation agree on where the row lands."""
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)], limit=1)
+        for vals in values:
+            if "location_id" not in vals:
+                vals["location_id"] = warehouse.lot_stock_id.id
+
+    def _normalize_import_lot(self, vals):
+        """A lot name is only unique per product, so the importer may resolve it to another
+        product's lot. Re-point it to this product's lot when it exists, as core does on
+        creation, otherwise the lookup would miss and duplicate the line."""
+        product = self.env["product.product"].browse(vals.get("product_id"))
+        lot = self.env["stock.lot"].browse(vals.get("lot_id"))
+        if product and lot and lot.product_id != product:
+            lot = self.env["stock.lot"].search([("product_id", "=", product.id), ("name", "=", lot.name)], limit=1)
+            if lot:
+                vals["lot_id"] = lot.id
+
+    def _index_import_quants(self, values):
+        """The quants the imported rows may already hold, in a single search: a count of
+        thousands of lines would otherwise search once per row."""
+        products = {vals["product_id"] for vals in values if vals.get("product_id")}
+        locations = {vals["location_id"] for vals in values if vals.get("location_id")}
+        if not products or not locations:
+            return {}
+        # No sudo: a row can only land on a quant its author is allowed to see.
+        quants = self.search(
+            [("product_id", "in", list(products)), ("location_id", "in", list(locations))],
+            order="in_date, id",
+        )
+        index = {}
+        for quant in quants:
+            key = self._get_import_quant_key(
+                quant.product_id.id,
+                quant.location_id.id,
+                quant.lot_id.id,
+                quant.package_id.id,
+                quant.owner_id.id,
+            )
+            # A position holding more than one quant is what core's merge undoes: keep the
+            # one it keeps.
+            index.setdefault(key, quant)
+        return index
+
+    def _write_imported_quantity(self, quant, vals):
+        """Apply an imported row on the quant it matched, the same way core applies it on
+        the quant it gathers when it is not importing."""
+        quant = quant.with_context(inventory_mode=True)
+        if "inventory_quantity_auto_apply" in vals:
+            quant.write({"inventory_quantity_auto_apply": vals.get("inventory_quantity_auto_apply") or 0})
+        else:
+            quant.write(
+                {
+                    "inventory_quantity": vals.get("inventory_quantity") or 0,
+                    # a counted 0 on a line that was never counted writes no value, and an
+                    # unset line shows no difference and stays out of "Apply all"
+                    "inventory_quantity_set": True,
+                    "user_id": vals.get("user_id") or self.env.user.id,
+                    "inventory_date": vals.get("inventory_date") or fields.Date.today(),
+                }
+            )
+        return quant
+
+    def _load_records_create(self, values):
+        """On import, write the counted quantity on the quant that already holds that
+        product/location/lot/package/owner instead of adding a second line that sums up.
+        Core skips that lookup while importing to keep one row = one record, an invariant
+        this override must preserve: it returns exactly one record per row, in order."""
+        if not self._is_import_counting():
+            return super()._load_records_create(values)
+        self._set_import_default_location(values)
+        for vals in values:
+            self._normalize_import_lot(vals)
+        index = self._index_import_quants(values)
+        records = [None] * len(values)
+        pending = {}
+        for position, vals in enumerate(values):
+            # A row carrying no count is not a count: writing a 0 on the line it names
+            # would empty stock nobody asked to empty.
+            counted = any(f in vals for f in ("inventory_quantity", "inventory_quantity_auto_apply"))
+            key = self._get_import_quant_key(
+                vals.get("product_id"),
+                vals.get("location_id"),
+                vals.get("lot_id"),
+                vals.get("package_id"),
+                vals.get("owner_id"),
+            )
+            quant = index.get(key) if vals.get("product_id") else None
+            if quant:
+                # A row that names a line without counting it says nothing about it.
+                records[position] = self._write_imported_quantity(quant, vals) if counted else quant
+                continue
+            # Rows sharing a key are the same line, so the last count wins, as it would
+            # if the first of them had already created that line.
+            group = key if counted and vals.get("product_id") else ("row", position)
+            entry = pending.setdefault(group, {"positions": []})
+            entry["positions"].append(position)
+            entry["vals"] = vals
+        if pending:
+            created = super()._load_records_create([entry["vals"] for entry in pending.values()])
+            for entry, record in zip(pending.values(), created):
+                for position in entry["positions"]:
+                    records[position] = record
+        return self.browse(tuple(record.id for record in records))

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import test_mto_warehouse_propagation
 from . import test_product_uom_qty_location
+from . import test_quant_import

--- a/stock_ux/tests/test_quant_import.py
+++ b/stock_ux/tests/test_quant_import.py
@@ -1,0 +1,163 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase, new_test_user
+
+
+@tagged("stock_ux_quant_import")
+class TestQuantImport(TransactionCase):
+    """An imported count must replace the quantity of the stock line it belongs to."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref("stock.group_stock_manager")
+        cls.env.user.group_ids += cls.env.ref("stock_ux.group_stock_inventory_adjustment")
+        cls.location = cls.env.ref("stock.stock_location_stock")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Counted Product",
+                "is_storable": True,
+            }
+        )
+        cls.env["stock.quant"]._update_available_quantity(cls.product, cls.location, 10)
+
+    def _load(self, fields, rows, user=None):
+        quants = self.env["stock.quant"]
+        return quants.with_user(user or self.env.user).with_context(import_file=True).load(fields, rows)
+
+    def _import(self, fields, rows):
+        result = self._load(fields, rows)
+        self.assertFalse(
+            [message for message in result["messages"] if message["type"] == "error"],
+            result["messages"],
+        )
+        return result
+
+    def _quants(self, product=None):
+        return self.env["stock.quant"].search(
+            [
+                ("product_id", "=", (product or self.product).id),
+                ("location_id", "=", self.location.id),
+            ]
+        )
+
+    def test_import_replaces_the_counted_quantity(self):
+        self._import(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[self.product.name, self.location.complete_name, "4"]],
+        )
+        quant = self._quants()
+        self.assertEqual(len(quant), 1, "the count must land on the existing line")
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, 4, "10 counted as 4 must end up as 4, not as 14")
+
+    def test_import_zero_empties_the_line(self):
+        self._import(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[self.product.name, self.location.complete_name, "0"]],
+        )
+        quant = self._quants()
+        self.assertTrue(quant.inventory_quantity_set, "a counted 0 is a count, not an empty cell")
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, 0)
+
+    def test_import_creates_the_line_when_there_is_none(self):
+        other = self.env["product.product"].create({"name": "Uncounted Product", "is_storable": True})
+        self._import(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[other.name, self.location.complete_name, "7"]],
+        )
+        quant = self._quants(other)
+        self.assertEqual(len(quant), 1)
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, 7)
+
+    def test_import_matches_the_lot_of_the_row_product(self):
+        """A lot name is only unique per product: the importer resolves it to whichever
+        product's lot comes first, so the match has to re-point it."""
+        tracked = self.env["product.product"].create(
+            {
+                "name": "Tracked Product",
+                "is_storable": True,
+                "tracking": "lot",
+            }
+        )
+        homonym = self.env["product.product"].create(
+            {
+                "name": "Homonym Lot Product",
+                "is_storable": True,
+                "tracking": "lot",
+            }
+        )
+        self.env["stock.lot"].create({"name": "L1", "product_id": homonym.id})
+        lot = self.env["stock.lot"].create({"name": "L1", "product_id": tracked.id})
+        self.env["stock.quant"]._update_available_quantity(tracked, self.location, 10, lot_id=lot)
+
+        self._import(
+            ["product_id", "location_id", "lot_id", "inventory_quantity"],
+            [[tracked.name, self.location.complete_name, "L1", "4"]],
+        )
+        quant = self._quants(tracked)
+        self.assertEqual(len(quant), 1, "the count must land on the lot of this product")
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, 4)
+
+    def test_import_of_the_on_hand_column_applies_on_the_line(self):
+        """The inventoried quantity applies itself, so it has to land on the right line."""
+        self._import(
+            ["product_id", "location_id", "inventory_quantity_auto_apply"],
+            [[self.product.name, self.location.complete_name, "4"]],
+        )
+        quant = self._quants()
+        self.assertEqual(len(quant), 1)
+        self.assertEqual(quant.quantity, 4)
+
+    def test_row_without_a_count_leaves_the_line_alone(self):
+        """A file with no counted quantity column is not a count of zero."""
+        self._import(
+            ["product_id", "location_id"],
+            [[self.product.name, self.location.complete_name]],
+        )
+        quant = self._quants()
+        self.assertEqual(len(quant), 1, "the row names a line, it does not add one")
+        self.assertFalse(quant.inventory_quantity_set, "no row said 0")
+
+    def test_blank_count_leaves_the_line_alone(self):
+        """Counting part of an exported file is the ordinary file: the rows left blank
+        are not counts of zero."""
+        self._import(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[self.product.name, self.location.complete_name, ""]],
+        )
+        quant = self._quants()
+        self.assertEqual(len(quant), 1)
+        self.assertFalse(quant.inventory_quantity_set, "an empty cell is not a counted 0")
+        self.assertEqual(quant.quantity, 10, "applying it would have emptied the line")
+
+    def test_two_rows_for_the_same_line_count_it_once(self):
+        other = self.env["product.product"].create({"name": "Twice Counted", "is_storable": True})
+        self._import(
+            ["product_id", "location_id", "inventory_quantity"],
+            [
+                [other.name, self.location.complete_name, "4"],
+                [other.name, self.location.complete_name, "7"],
+            ],
+        )
+        quant = self._quants(other)
+        self.assertEqual(len(quant), 1, "both rows are the same stock line")
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, 7, "the last count of a line wins, it is not added up")
+
+    def test_import_without_the_adjustment_group_changes_nothing(self):
+        """Applying a count needs the adjustment group, importing one cannot go around it."""
+        plain = new_test_user(self.env, login="plain_stock_user", groups="stock.group_stock_user")
+
+        result = self._load(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[self.product.name, self.location.complete_name, "4"]],
+            user=plain,
+        )
+
+        self.assertTrue([message for message in result["messages"] if message["type"] == "error"])
+        quant = self._quants()
+        self.assertEqual(quant.quantity, 10)
+        self.assertFalse(quant.inventory_quantity_set)


### PR DESCRIPTION
### What

While importing, `stock.quant.create` skips the lookup of the existing quant so that one row stays one record. Every imported row therefore created a second line for a product that already had stock in that location, and the counted quantity ended up **added** to the stock on hand instead of replacing it. A counted `0` did nothing at all, because the count landed on a brand new empty line.

`_load_records_create` now resolves the quant by its natural key — product, location, lot, package and owner — and writes the count on it, creating the line only when there is none. It is the inverse of the skip core does while importing.

### Notes

- The override returns exactly one record per row, in order, so the invariant the core skip protects is preserved (`_load_records` zips its result with the rows it was handed). Rows sharing a key are the same line: the last count wins, instead of two lines that core's merge would later add up.
- A lot name is only unique per product and the importer resolves it with a plain `name_search`, so a lot that resolved to another product's is re-pointed before matching. Without that, a tracked product duplicates its line all the same.
- `inventory_quantity_set` is written explicitly: writing a counted `0` over a line that was never counted is a no-op write, the compute would not run, and the line would show no difference and stay out of "Apply all".
- **Only a row that actually counts is a count.** A row with no counted quantity column, or with that cell left empty, names its line without saying anything about it, so it comes out untouched. Counting part of an exported file is the ordinary file, and an empty cell has to stay apart from a counted `0` — the converter turns both into the same `0.0`, which is why they are told apart while the rows are still the strings of the file.
- Only someone allowed to adjust inventory gets a count applied: without `stock_ux.group_stock_inventory_adjustment` the rows fall back to what core answers, instead of being written as superuser. The lookup runs with the author's own rights, so a row can only land on a line they are allowed to see.
- One indexed lookup for the whole file rather than one per row, which is what a count of thousands of lines is.

### Test plan

`stock_ux/tests/test_quant_import.py`, 9 tests: an existing line is replaced and not added up; a counted `0` empties the line; a line is still created when there is none; the lot matched is the one of the row's product; the inventoried quantity column applies on the right line; two rows for the same line count it once; a row with no counted quantity column leaves the line alone; a row with that cell empty leaves the line alone; an import by a user without the adjustment group changes nothing.

Ran on 19.0: `0 failed, 0 error(s) of 17 tests`. With the model file reverted, 6 of the 9 fail — e.g. `AssertionError: 2 != 1 : the count must land on the existing line`. The other three are guards, each failing against an earlier version of this branch: `an empty cell is not a counted 0`, `no row said 0`, and the count being applied without the group.

Task: https://www.adhoc.inc/odoo/all-tasks/12857/all-tasks/71351