### PR TITLE
[FIX] stock_ux: say which row an inventory import cannot take

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -40,6 +40,8 @@ Stock UX
 #. Add a "All transfers" view form in Menu: Operations
 #. Add a restriction to edit operation type for users with the "Restrict editing Operation Type in Pickings" check.
 #. Add number of packages on pickings
+#. Accept the columns identifying a stock line on import while they repeat what the line already holds, so a file exported from Odoo can be re-imported as it is, and name the line and the column when they do not.
+#. Report which row, product or column an inventory import cannot take, instead of one message for the whole file, and refuse the columns that would move stock with no move behind them.
 
 Installation
 ============

--- a/stock_ux/models/stock_quant.py
+++ b/stock_ux/models/stock_quant.py
@@ -2,7 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import _, api, models
+from odoo.exceptions import UserError, ValidationError
 
 
 class StockQuant(models.Model):
@@ -18,3 +19,106 @@ class StockQuant(models.Model):
         return self.env.context.get("inventory_mode") and self.env.user.has_group(
             "stock_ux.group_stock_inventory_adjustment"
         )
+
+    # ------------------------------------------------------------------
+    # Actionable messages: name the offending column, product or line so the
+    # importer points at the row instead of collapsing into "multiple rows"
+    # ------------------------------------------------------------------
+
+    def load(self, fields, data):
+        """An inventory adjustment only takes the counted quantity and the columns that
+        identify the stock line. Core answers a column it cannot take with a message that
+        names none of them, and lets the on hand quantity through on the update path,
+        moving stock with no move behind it."""
+        if self.env.context.get("import_file"):
+            wrong = self._get_non_importable_columns(fields)
+            if wrong:
+                return self._import_refused(
+                    _(
+                        'The column "%(columns)s" cannot be imported into an inventory '
+                        "adjustment: it only takes the counted quantity and the columns "
+                        "identifying the stock line. Remove it from the file.",
+                        columns='", "'.join(wrong.values()),
+                    )
+                )
+            guessed = self._get_guessed_import_location(fields)
+            if guessed:
+                return self._import_refused(
+                    _(
+                        "The file does not say where the count was taken and there is more "
+                        "than one warehouse to take it in, so every row would land in "
+                        '"%(location)s". Add the location column, or the column that '
+                        "identifies each stock line.",
+                        location=guessed.display_name,
+                    )
+                )
+        return super().load(fields, data)
+
+    def _import_refused(self, message):
+        """A file that cannot be imported as it stands, answered the way load() answers."""
+        return {"ids": False, "messages": [{"type": "error", "message": message}], "nextrow": 0}
+
+    def _get_guessed_import_location(self, field_paths):
+        """The location every row would land in when the file names none, and there is more
+        than one to choose from. A count taken in the wrong warehouse reads as real stock."""
+        names = [path.split("/")[0] for path in field_paths]
+        if {"location_id", "id", ".id"} & set(names):
+            return self.env["stock.location"]
+        warehouses = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)])
+        if len(warehouses) < 2:
+            return self.env["stock.location"]
+        return warehouses[0].lot_stock_id
+
+    def _get_non_importable_columns(self, field_paths):
+        """Columns of the file that an inventory adjustment cannot take, by label."""
+        names = [path.split("/")[0] for path in field_paths]
+        allowed = self._get_inventory_fields_create() + ["id", ".id"]
+        wrong = [name for name in names if name not in allowed and not name.startswith("x_")]
+        if not wrong:
+            # fields_get() answers an empty list with every field of the model
+            return {}
+        return {name: values["string"] for name, values in self.fields_get(wrong, ["string"]).items()}
+
+    def write(self, vals):
+        """A key field repeating the value the quant already has is not an edit: every file
+        built from an export carries those columns. Only a different value is refused, and
+        it says which line and which column disagree."""
+        forbidden = [f for f in self._get_forbidden_fields_write() if f in vals]
+        if (
+            forbidden
+            and self._is_inventory_mode()
+            and not any(quant.location_id.usage == "inventory" for quant in self)
+        ):
+            for quant in self:
+                conflicting = [f for f in forbidden if quant[f].id != (vals[f] or False)]
+                if conflicting:
+                    field = conflicting[0]
+                    raise UserError(
+                        _(
+                            'The stock line "%(quant)s" cannot be moved to another '
+                            '"%(field)s" from a file: it holds "%(current)s" and the file '
+                            'brings "%(new)s". Product, location, lot, package and owner '
+                            "identify the line: fix that row or drop the column.",
+                            quant=quant.sudo().display_name,
+                            field=self.fields_get([field], ["string"])[field]["string"],
+                            current=quant.sudo()[field].display_name or _("empty"),
+                            new=self.env[self._fields[field].comodel_name].browse(vals[field]).sudo().display_name
+                            or _("empty"),
+                        )
+                    )
+            vals = {k: v for k, v in vals.items() if k not in forbidden}
+        return super().write(vals)
+
+    @api.constrains("product_id")
+    def check_product_id(self):
+        """Same guard as core, naming the products and the real cause: inventory tracking."""
+        wrong = self.filtered(lambda quant: not quant.product_id.is_storable)
+        if wrong:
+            raise ValidationError(
+                _(
+                    'The product "%(products)s" does not track inventory, so it cannot hold '
+                    'stock. Enable "Track Inventory" on the product or remove its rows from '
+                    "the file.",
+                    products='", "'.join(wrong.sudo().product_id.mapped("display_name")),
+                )
+            )

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import test_mto_warehouse_propagation
 from . import test_product_uom_qty_location
+from . import test_quant_import_messages

--- a/stock_ux/tests/test_quant_import_messages.py
+++ b/stock_ux/tests/test_quant_import_messages.py
@@ -1,0 +1,105 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("stock_ux_quant_import")
+class TestQuantImportMessages(TransactionCase):
+    """An import must say which row is wrong and why, must not refuse a key column that
+    only repeats what the stock line already holds, and must not take a column that moves
+    stock behind the back of the adjustment."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref("stock.group_stock_manager")
+        cls.env.user.group_ids += cls.env.ref("stock_ux.group_stock_inventory_adjustment")
+        cls.location = cls.env.ref("stock.stock_location_stock")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Counted Product",
+                "is_storable": True,
+            }
+        )
+        cls.env["stock.quant"]._update_available_quantity(cls.product, cls.location, 10)
+        cls.quant = cls.env["stock.quant"].search(
+            [
+                ("product_id", "=", cls.product.id),
+                ("location_id", "=", cls.location.id),
+            ]
+        )
+
+    def _load(self, fields, rows):
+        return self.env["stock.quant"].with_context(import_file=True).load(fields, rows)
+
+    def _errors(self, result):
+        return [message for message in result["messages"] if message["type"] == "error"]
+
+    def test_export_and_reimport_keeps_the_key_columns(self):
+        """The file everybody builds is an export: it carries the key columns untouched."""
+        fields = ["id", "product_id", "location_id", "inventory_quantity"]
+        rows = self.quant.export_data(fields)["datas"]
+        rows[0][3] = "4"
+
+        result = self._load(fields, rows)
+
+        self.assertFalse(self._errors(result), self._errors(result))
+        self.quant.action_apply_inventory()
+        self.assertEqual(self.quant.quantity, 4)
+
+    def test_moving_a_line_to_another_product_still_refused(self):
+        other = self.env["product.product"].create({"name": "Other Product", "is_storable": True})
+        with self.assertRaises(UserError) as error:
+            self.quant.with_context(inventory_mode=True).write({"product_id": other.id})
+        self.assertIn(other.name, str(error.exception), "the message must name the conflict")
+
+    def test_untracked_product_is_reported_row_by_row(self):
+        untracked = [
+            self.env["product.product"].create({"name": name, "is_storable": False})
+            for name in ("Untracked One", "Untracked Two")
+        ]
+
+        result = self._load(
+            ["product_id", "location_id", "inventory_quantity"],
+            [[product.name, self.location.complete_name, "5"] for product in untracked],
+        )
+
+        errors = self._errors(result)
+        self.assertEqual(len(errors), 2, "each row gets its own message, not one for all")
+        for error, product in zip(errors, untracked):
+            self.assertIn(product.name, error["message"])
+            self.assertEqual(error["rows"]["from"], error["rows"]["to"], "the message must point at one row")
+
+    def test_column_that_cannot_be_imported_is_named(self):
+        result = self._load(
+            ["product_id", "location_id", "quantity", "inventory_quantity"],
+            [[self.product.name, self.location.complete_name, "10", "4"]],
+        )
+
+        errors = self._errors(result)
+        self.assertTrue(errors)
+        self.assertIn("Quantity", errors[0]["message"])
+
+    def test_on_hand_quantity_is_never_written_straight(self):
+        """Writing it would move stock with no move behind it, and core takes it silently
+        on the update path."""
+        rows = self.quant.export_data(["id"])["datas"]
+        rows[0].append("99")
+
+        result = self._load(["id", "quantity"], rows)
+
+        self.assertTrue(self._errors(result))
+        self.assertEqual(self.quant.quantity, 10, "the file cannot set the stock on hand")
+
+    def test_file_that_does_not_say_where_the_count_was_taken(self):
+        """With a virtual warehouse in the middle, guessing lands the count on stock that
+        looks real."""
+        fields = ["product_id", "inventory_quantity"]
+        rows = [[self.product.name, "4"]]
+        self.assertFalse(self._errors(self._load(fields, rows)), "one warehouse, nothing to guess")
+
+        self.env["stock.warehouse"].create({"name": "Second Warehouse", "code": "SWH"})
+        errors = self._errors(self._load(fields, rows))
+
+        self.assertTrue(errors)
+        self.assertIn(self.location.display_name, errors[0]["message"])


### PR DESCRIPTION
### What

Four things an inventory import says badly, or does not say at all.

**1. `Quant's editing is restricted, you can't do this operation.`** Any file built from an export carries the columns that identify the stock line, and re-importing it stops there. The guard looks at which columns are present, not at their values, so it cannot tell a line being moved to another product from one merely carrying the column it was exported with. A key column is now let through while it repeats what the line already holds, and refused — naming the line, the column, and both values — when it does not.

**2. `Quants cannot be created for consumables or services.`** A product that is a good but has "Track Inventory" off gets that message, which is not what it is, and neither message names the product. On a file of thousands of rows the importer collapses identical messages into "at multiple rows", so nothing points at the row to fix. Naming the product is what splits the messages apart: `load()` already attributes each error to its row, it is the identical text that makes the UI group them.

**3. Columns an adjustment cannot take.** On creation core answers them with `Quant's creation is restricted, you can't do this operation.`, naming none — and the template it offers ships two of them. On the update path it does not answer at all: a file with an `id` column and a `Quantity` column writes the on hand quantity straight onto the quant, moving stock with no move behind it and no message. Both paths now refuse the column by name.

**4. A file that does not say where the count was taken.** When no column names the location, every row silently lands in the stock location of the first warehouse of the company. With a second warehouse — a virtual one in the middle is the usual case — that puts the count of one warehouse onto the stock of another, and it reads as real stock from then on. The file is now refused, naming the location the rows would have landed in.

### Test plan

`stock_ux/tests/test_quant_import_messages.py`, 6 tests: a file exported from Odoo re-imports as it is; moving a line to another product is still refused and the message names the conflict; two rows of untracked products get two messages, each naming its product and pointing at a single row; a column an adjustment cannot take is named; an imported on hand quantity leaves the stock untouched; a file with no location column loads while there is one warehouse and is refused once there are two.

Ran on 19.0: `0 failed, 0 error(s) of 14 tests`. With the model file reverted, the 6 fail — e.g. `AssertionError: 'Untracked One' not found in 'Quants cannot be created for consumables or services.'`, and the stock on hand going from 10 to 99 with no move.

Independent of #1007, #1009 and #1025, which cover the same import from other ends. Merging them together leaves a trivial conflict in the README and in `tests/__init__.py`.

Task: https://www.adhoc.inc/odoo/all-tasks/12857/all-tasks/71351