### PR TITLE
[IMP] stock_currency_valuation_recompute: work from the list, and correct a revaluation

### DIFF
--- a/stock_currency_valuation_recompute/README.rst
+++ b/stock_currency_valuation_recompute/README.rst
@@ -65,6 +65,27 @@ To use this module, you need to:
 #. Create a record, choose the product and press "Compute lines"
 #. Review the proposed values, they are not written yet
 #. Press "Revaluate" to apply them
+#. To work on several at a time, tick them in the list and use the "Compute lines" and
+   "Revaluate" buttons of the header
+
+Computing lines does not touch the layers or their journal entries — all it writes are the
+recompute's own proposed lines — so the header button does it in the request and you see
+the result straight away. It still replays the whole valuation history of every product in
+the selection, so a selection of many products with long histories can run past the request
+timeout; if that happens nothing is saved, so work in smaller groups.
+
+Revaluating does write on the layers and on their journal entries, so the header button
+applies nothing however many records you select: it moves them to *Revaluating*, and a
+scheduled action applies them one by one in the background. Nothing to wait for on screen,
+and no selection large enough to time out the request. Cancelling a record before the
+scheduled action reaches it takes it out of the queue.
+
+A record that fails is left in *Error* with the reason on it, and the rest of the batch
+carries on. It is not retried on its own: the usual reason is a correction that starts
+before the fiscal lock date, which retrying does not fix. Filter the list by *Error* to see
+them; once the cause is sorted out, compute their lines again — which clears the reason —
+and revaluate. Only a record with computed lines can be revaluated, so a failure of the
+compute step can never be applied.
 
 Known issues / Roadmap
 ======================

--- a/stock_currency_valuation_recompute/__manifest__.py
+++ b/stock_currency_valuation_recompute/__manifest__.py
@@ -32,6 +32,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "data/ir_cron.xml",
         "views/stock_valuation_layer_recompute.xml",
     ],
     "demo": [],

--- a/stock_currency_valuation_recompute/data/ir_cron.xml
+++ b/stock_currency_valuation_recompute/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="cron_revaluate_queued" model="ir.cron">
+        <field name="name">Stock Currency Valuation: revaluate queued recomputes</field>
+        <field name="model_id" ref="model_stock_valuation_layer_recompute"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_revaluate_queued()</field>
+        <!-- Si no se declara, queda el usuario que instalo el modulo: la revaluacion
+             reescribe asientos, y de quien depende que pueda hacerlo no puede ser un accidente. -->
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">15</field>
+        <field name="interval_type">minutes</field>
+    </record>
+</odoo>

--- a/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
+++ b/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
@@ -1,5 +1,25 @@
+import logging
+import time
+
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+# Segundos de trabajo por invocacion del cron. No es un tope de lo que se puede encolar:
+# el cron reporta cuantos quedan y Odoo lo relanza enseguida hasta vaciar la cola.
+#
+# Es un presupuesto de tiempo y no una cantidad de registros porque lo que hay que no
+# pasarse es el `--limit-time-real-cron` del worker (por defecto cae en
+# `--limit-time-real`, 120 segundos): pasado ese tiempo mata el thread. Un numero fijo de
+# registros no protege eso, porque revaluar un producto con 500 layers no cuesta lo mismo
+# que uno con 5.
+#
+# El valor es chico porque el presupuesto es POR INVOCACION y no por thread:
+# `ir.cron._run_job` reinvoca el callback hasta `MAX_BATCH_PER_CRON_JOB` (10) veces
+# seguidas mientras quede trabajo, commiteando entre una y otra. Diez invocaciones tienen
+# que entrar en el limite del worker, asi que el presupuesto va en el orden de un decimo.
+REVALUATION_TIME_BUDGET = 10
 
 
 class StockValuationLayerRecompute(models.Model):
@@ -23,6 +43,7 @@ class StockValuationLayerRecompute(models.Model):
     last_manual_svl_id = fields.Many2one("stock.valuation.layer")
     amount_changed = fields.Boolean()
     slv_changed = fields.Boolean()
+    revaluation_error = fields.Text(readonly=True, copy=False)
     final_rate = fields.Float(
         compute="_compute_final_rate",
         store=True,
@@ -32,8 +53,10 @@ class StockValuationLayerRecompute(models.Model):
         [
             ("draft", "Draft"),
             ("in_process", "In Process"),
+            ("revaluating", "Revaluating"),
             ("done", "Done"),
             ("no_change", "Not changes Required"),
+            ("error", "Error"),
             ("cancel", "Cancelled"),
         ],
         default="draft",
@@ -133,6 +156,7 @@ class StockValuationLayerRecompute(models.Model):
             raise UserError("El producto tiene valuación por lote (lot_valuated) y este recálculo no la contempla.")
 
     def action_compute_lines(self):
+        self.ensure_one()
         self._check_supported_product()
 
         last_manual_svl_id = self.env["stock.valuation.layer"].search(
@@ -374,6 +398,7 @@ class StockValuationLayerRecompute(models.Model):
         self.final_amount_in_currency = standard_price_in_currency
         self.final_amount = standard_price
         self.state = "in_process"
+        self.revaluation_error = False
         self.action_check_need_changes()
 
     def action_check_need_changes(self):
@@ -385,6 +410,11 @@ class StockValuationLayerRecompute(models.Model):
             self.state = "no_change"
 
     def action_manual_slv_revaluation(self):
+        self.ensure_one()
+        # Sin lineas no hay nada calculado, y los importes finales estan en cero: aplicar
+        # escribiria 0 en el costo del producto sin dejar rastro en ningun layer.
+        if not self.line_ids:
+            raise UserError(_("Compute the lines before revaluating %s.", self.display_name))
         self._check_supported_product()
         slv_changed = False
         # to_reconciled_line_ids guarda todas las conciliaciones
@@ -445,6 +475,79 @@ class StockValuationLayerRecompute(models.Model):
             if not any(to_reconciled_lines.mapped("reconciled")):
                 to_reconciled_lines.reconcile()
         self.state = "done"
+        self.revaluation_error = False
+
+    def _batch_selection(self, states):
+        """Registros de la seleccion sobre los que corresponde correr la accion masiva."""
+        records = self.filtered(lambda rec: rec.state in states)
+        if not records:
+            raise UserError(_("None of the selected records is in a state that allows this action."))
+        return records
+
+    def _apply_isolated(self, method_name):
+        """Corre `method_name` sobre este registro, aislado en su propio savepoint.
+
+        Uno que falla no se lleva a los demas de la tanda: se revierte solo y queda en
+        `error` con el motivo a la vista. Se atrapa `UserError` y sus subclases, que es
+        todo lo que levanta el propio flujo (incluidos los de validacion y de acceso). Un
+        fallo de infraestructura —un deadlock, un conflicto de serializacion— no es
+        `UserError` y se propaga a proposito: parquearlo en un estado que nadie reintenta
+        solo lo haria pasar por un rechazo definitivo.
+        """
+        self.ensure_one()
+        try:
+            with self.env.cr.savepoint():
+                getattr(self, method_name)()
+        except UserError as error:
+            self.write({"state": "error", "revaluation_error": str(error)})
+            _logger.warning("%s failed on recompute %s: %s", method_name, self.id, error)
+
+    def action_compute_lines_multi(self):
+        """Boton de la vista lista: recalcula la seleccion de a un registro.
+
+        Sin tope de registros. Recalcular no toca los layers ni sus asientos —lo unico
+        que escribe son las lineas propuestas del propio recompute— asi que se hace en el
+        request y el operador ve el resultado al toque.
+        """
+        for rec in self._batch_selection(("draft", "in_process", "no_change", "error")):
+            rec._apply_isolated("action_compute_lines")
+            # El cache crece con cada producto (sus layers, sus asientos): en una
+            # seleccion grande hay que soltarlo o la memoria no para de subir.
+            self.env.invalidate_all()
+
+    def action_queue_revaluation(self):
+        """Boton de la vista lista: encola la seleccion para que la revalue el cron.
+
+        No revalua en el request. Aplicar un registro reescribe los asientos de cada
+        layer que cambia, asi que una seleccion grande se pasa del timeout y no queda
+        nada aplicado. Encolar es una escritura de estado, cueste lo que cueste la cola.
+        """
+        records = self._batch_selection(("in_process",))
+        records.write({"state": "revaluating", "revaluation_error": False})
+        self.env.ref("stock_currency_valuation_recompute.cron_revaluate_queued").sudo()._trigger()
+
+    @api.model
+    def _cron_revaluate_queued(self):
+        """Revalua los encolados de a uno hasta agotar el presupuesto de tiempo."""
+        started = time.monotonic()
+        # Solo los ids: iterar el recordset entero traeria de una las lineas de los cientos
+        # de encolados, cuando en el presupuesto entra un punado.
+        queued_ids = self.search([("state", "=", "revaluating")]).ids
+        for done, rec_id in enumerate(queued_ids, start=1):
+            # sudo y la compania del registro: el usuario del cron no tiene por que estar
+            # habilitado en la compania donde se valua el producto, y sin eso los layers y
+            # los asientos de otra compania no se pueden ni leer.
+            rec = self.browse(rec_id).sudo()
+            if rec.state == "revaluating":
+                # La cola se leyo al arrancar: entre eso y ahora lo pueden haber cancelado.
+                rec.with_company(rec.company_id)._apply_isolated("action_manual_slv_revaluation")
+            # Adentro del loop: si algo corta la corrida, lo hecho hasta aca cuenta como
+            # progreso y el corte no se anota como falla del cron. Y mientras `remaining`
+            # no llegue a cero, Odoo lo relanza enseguida en vez de esperar el intervalo.
+            self.env["ir.cron"]._notify_progress(done=done, remaining=len(queued_ids) - done)
+            self.env.invalidate_all()
+            if time.monotonic() - started > REVALUATION_TIME_BUDGET:
+                break
 
 
 class StockValuationLayerRecomputeLine(models.Model):

--- a/stock_currency_valuation_recompute/tests/test_layer_recompute.py
+++ b/stock_currency_valuation_recompute/tests/test_layer_recompute.py
@@ -1,61 +1,18 @@
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+MODEL_LOGGER = "odoo.addons.stock_currency_valuation_recompute.models.stock_valuation_layer_recompute"
 
 
 @tagged("post_install", "-at_install")
 class TestLayerRecompute(TransactionCase):
     def test_recompute_detects_out_valued_with_stale_cost(self):
         """Una salida valuada con el costo en moneda desactualizado tiene que salir marcada."""
-        company = self.env.company
-        categ = self.env["product.category"].create(
-            {
-                "name": "Categoria valuada en moneda",
-                "property_cost_method": "average",
-                "property_valuation": "manual_periodic",
-                "valuation_currency_id": self.env.ref("base.USD").id,
-            }
-        )
-        product = (
-            self.env["product.product"]
-            .create({"name": "Producto valuado en moneda", "is_storable": True, "categ_id": categ.id})
-            .with_company(company)
-        )
-        product.standard_price = 1000.0
-        product.standard_price_in_currency = 10.0
-
-        warehouse = self.env["stock.warehouse"].search([("company_id", "=", company.id)], limit=1)
-        quant = self.env["stock.quant"].with_context(inventory_mode=True)
-        # ingreso 10 unidades
-        quant.create(
-            {
-                "product_id": product.id,
-                "location_id": warehouse.lot_stock_id.id,
-                "inventory_quantity": 10.0,
-            }
-        ).action_apply_inventory()
-
-        # revaluacion que en 18.0 no impactaba la ficha: el layer queda en 50 USD
-        # pero el costo en moneda del producto sigue en 10
-        revaluation_layer = self.env["stock.valuation.layer"].create(
-            {
-                "company_id": company.id,
-                "product_id": product.id,
-                "description": "Manual Stock Valuation: test.",
-                "value": 5000.0,
-                "value_in_currency": 50.0,
-                "quantity": 0,
-            }
-        )
-
-        # salida de 2 unidades, valuada con el costo en moneda desactualizado
-        quant.search([("product_id", "=", product.id), ("location_id", "=", warehouse.lot_stock_id.id)]).write(
-            {"inventory_quantity": 8.0}
-        )
-        quant.search(
-            [("product_id", "=", product.id), ("location_id", "=", warehouse.lot_stock_id.id)]
-        ).action_apply_inventory()
+        product, revaluation_layer = self._make_product_with_drift("Producto valuado en moneda")
 
         recompute = self.env["stock.valuation.layer.recompute"].create(
-            {"company_id": company.id, "product_id": product.id}
+            {"company_id": self.env.company.id, "product_id": product.id}
         )
         recompute.action_compute_lines()
 
@@ -91,3 +48,175 @@ class TestLayerRecompute(TransactionCase):
                 "Un layer que no se escribe no puede aportar al promedio un valor distinto al registrado",
             )
             self.assertEqual(line.new_value, line.layer_value)
+
+    def test_compute_lines_multi_processes_every_selected_record(self):
+        """El boton de la lista recalcula cada registro de la seleccion, no solo el primero."""
+        Recompute = self.env["stock.valuation.layer.recompute"]
+        recomputes = Recompute.create(
+            [
+                {"company_id": self.env.company.id, "product_id": self._make_product_with_layer("Producto A").id},
+                {"company_id": self.env.company.id, "product_id": self._make_product_with_layer("Producto B").id},
+            ]
+        )
+
+        recomputes.action_compute_lines_multi()
+
+        for recompute in recomputes:
+            self.assertTrue(recompute.line_ids, "Cada registro seleccionado tiene que quedar recalculado")
+            self.assertNotEqual(recompute.state, "draft")
+
+    @mute_logger(MODEL_LOGGER)
+    def test_compute_lines_multi_isolates_the_record_that_fails(self):
+        """Un producto no soportado no puede tirar abajo el recalculo de toda la seleccion."""
+        Recompute = self.env["stock.valuation.layer.recompute"]
+        failing = Recompute.create(
+            {"company_id": self.env.company.id, "product_id": self._make_product("Por lote", by_lot=True).id}
+        )
+        healthy = Recompute.create(
+            {"company_id": self.env.company.id, "product_id": self._make_product_with_layer("Producto sano").id}
+        )
+
+        (failing | healthy).action_compute_lines_multi()
+
+        self.assertEqual(failing.state, "error")
+        self.assertTrue(failing.revaluation_error, "Tiene que quedar el motivo a la vista")
+        self.assertTrue(healthy.line_ids, "El que falla no puede arrastrar al resto de la seleccion")
+
+    def test_queue_revaluation_has_no_limit(self):
+        """Encolar es una escritura de estado: no hay tope de cuantos se pueden mandar."""
+        recomputes = self.env["stock.valuation.layer.recompute"].create(
+            [{"company_id": self.env.company.id} for _unused in range(35)]
+        )
+        recomputes.state = "in_process"
+
+        recomputes.action_queue_revaluation()
+
+        self.assertEqual(set(recomputes.mapped("state")), {"revaluating"})
+
+    def test_cron_drains_the_queue(self):
+        """El cron aplica lo encolado y lo deja en done."""
+        recompute = self._make_computed_recompute("Producto A")
+        recompute.action_queue_revaluation()
+
+        self.env["stock.valuation.layer.recompute"]._cron_revaluate_queued()
+
+        self.assertEqual(recompute.state, "done")
+
+    def test_cron_respects_a_record_taken_out_of_the_queue(self):
+        """Si lo cancelan despues de encolarlo, el cron no lo aplica igual."""
+        Recompute = self.env["stock.valuation.layer.recompute"]
+        stays = self._make_computed_recompute("Producto A")
+        cancelled = self._make_computed_recompute("Producto B")
+        (stays | cancelled).action_queue_revaluation()
+        cancelled.action_cancel()
+
+        Recompute._cron_revaluate_queued()
+
+        self.assertEqual(cancelled.state, "cancel", "Cancelar tiene que sacarlo de la cola de verdad")
+        self.assertEqual(stays.state, "done")
+
+    def test_a_record_without_lines_cannot_be_revaluated(self):
+        """Aplicar sin lineas calculadas pondria el costo del producto en cero."""
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": self._make_product("Producto A").id}
+        )
+        recompute.state = "in_process"
+
+        with self.assertRaises(UserError):
+            recompute.action_manual_slv_revaluation()
+
+    def test_a_failed_compute_cannot_be_queued_for_revaluation(self):
+        """Un registro que quedo en error por el recalculo no se encola: hay que recalcular."""
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": self._make_product("Producto A").id}
+        )
+        recompute.write({"state": "error", "revaluation_error": "fallo el recalculo"})
+
+        with self.assertRaises(UserError):
+            recompute.action_queue_revaluation()
+
+    def test_a_retry_that_works_clears_the_previous_error(self):
+        """El motivo de una falla vieja no puede sobrevivir a un recalculo exitoso."""
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": self._make_product_with_layer("Producto A").id}
+        )
+        recompute.write({"state": "error", "revaluation_error": "fallo la vez pasada"})
+
+        recompute.action_compute_lines()
+
+        self.assertFalse(recompute.revaluation_error, "Un registro sano no puede mostrar un motivo de falla")
+
+    def test_queue_revaluation_skips_records_already_applied(self):
+        """Encolar en masa no vuelve a mandar un registro ya aplicado."""
+        recompute = self.env["stock.valuation.layer.recompute"].create({"company_id": self.env.company.id})
+        recompute.state = "done"
+
+        with self.assertRaises(UserError):
+            recompute.action_queue_revaluation()
+
+    def _make_computed_recompute(self, name):
+        """Recompute ya calculado y con diferencias, o sea aplicable."""
+        product, _revaluation_layer = self._make_product_with_drift(name)
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": product.id}
+        )
+        recompute.action_compute_lines()
+        self.assertEqual(recompute.state, "in_process", "El fixture tiene que dar diferencias")
+        return recompute
+
+    def _make_product_with_drift(self, name):
+        """Producto cuyo costo en moneda quedo desalineado de sus layers: el caso que el
+        modulo repara. Devuelve el producto y el layer del ajuste manual."""
+        company = self.env.company
+        product = self._make_product_with_layer(name)
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", company.id)], limit=1)
+        quant = self.env["stock.quant"].with_context(inventory_mode=True)
+
+        # revaluacion que en 18.0 no impactaba la ficha: el layer queda en 50 USD
+        # pero el costo en moneda del producto sigue en 10
+        revaluation_layer = self.env["stock.valuation.layer"].create(
+            {
+                "company_id": company.id,
+                "product_id": product.id,
+                "description": "Manual Stock Valuation: test.",
+                "value": 5000.0,
+                "value_in_currency": 50.0,
+                "quantity": 0,
+            }
+        )
+
+        # salida de 2 unidades, valuada con el costo en moneda desactualizado
+        domain = [("product_id", "=", product.id), ("location_id", "=", warehouse.lot_stock_id.id)]
+        quant.search(domain).write({"inventory_quantity": 8.0})
+        quant.search(domain).action_apply_inventory()
+        return product, revaluation_layer
+
+    def _make_product(self, name, by_lot=False):
+        """Producto valuado en moneda, opcionalmente valuado por lote (caso no soportado)."""
+        categ = self.env["product.category"].create(
+            {
+                "name": name,
+                "property_cost_method": "average",
+                "property_valuation": "manual_periodic",
+                "valuation_currency_id": self.env.ref("base.USD").id,
+            }
+        )
+        vals = {"name": name, "is_storable": True, "categ_id": categ.id}
+        if by_lot:
+            vals.update({"tracking": "lot", "lot_valuated": True})
+        return self.env["product.product"].create(vals).with_company(self.env.company)
+
+    def _make_product_with_layer(self, name):
+        """Producto valuado en moneda con una capa de valuacion, lo minimo para recalcular."""
+        product = self._make_product(name)
+        product.standard_price = 1000.0
+        product.standard_price_in_currency = 10.0
+        warehouse = self.env["stock.warehouse"].search([("company_id", "=", self.env.company.id)], limit=1)
+        self.env["stock.quant"].with_context(inventory_mode=True).create(
+            {
+                "product_id": product.id,
+                "location_id": warehouse.lot_stock_id.id,
+                "inventory_quantity": 10.0,
+            }
+        ).action_apply_inventory()
+        return product

--- a/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
+++ b/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
@@ -6,13 +6,16 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button name="action_compute_lines" type="object" string="Compute lines" invisible="state in ['done', 'cancel']"/>
-                    <button name="action_manual_slv_revaluation" type="object" string="Revaluate" class="btn-primary" invisible="state in ['draft', 'cancel', 'done']"/>
+                    <button name="action_compute_lines" type="object" string="Compute lines" invisible="state in ['revaluating', 'done', 'cancel']"/>
+                    <button name="action_manual_slv_revaluation" type="object" string="Revaluate" class="btn-primary" invisible="state in ['draft', 'revaluating', 'error', 'cancel', 'done']"/>
                     <button name="action_cancel" type="object" string="Cancel" invisible="state in ['done', 'cancel']"/>
                     <button name="back_to_draft" type="object" string="Back to Draft" invisible="state != 'cancel'"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,in_process,done,cancel"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,in_process,revaluating,done,cancel"/>
                 </header>
                 <sheet>
+                    <div class="alert alert-danger" role="alert" invisible="state != 'error'">
+                        <field name="revaluation_error" readonly="1" nolabel="1"/>
+                    </div>
                     <group>
                         <group colspan="2">
                             <field name="company_id" readonly="state != 'draft'"/>
@@ -62,6 +65,11 @@
         <field name="model">stock.valuation.layer.recompute</field>
         <field name="arch" type="xml">
             <list>
+                <header>
+                    <button name="action_compute_lines_multi" type="object" string="Compute lines"/>
+                    <button name="action_queue_revaluation" type="object" string="Revaluate" class="btn-primary"
+                        confirm="The selected records are queued and revaluated one by one in the background, writing on the layers and their journal entries. Continue?"/>
+                </header>
                 <field name="product_id"/>
                 <field name="valuation_currency_id"/>
                 <field name="amount_changed"/>
@@ -71,6 +79,7 @@
                 <field name="initial_amount_in_currency"/>
                 <field name="final_amount_in_currency"/>
                 <field name="state"/>
+                <field name="revaluation_error" optional="hide"/>
                 <field name="last_manual_svl_id"/>
             </list>
         </field>
@@ -83,7 +92,9 @@
             <search>
                 <filter string="Draft" name="filter_draft" domain="[('state', '=', 'draft')]"/>
                 <filter string="In Process" name="filter_in_process" domain="[('state', '=', 'in_process')]"/>
+                <filter string="Revaluating" name="filter_revaluating" domain="[('state', '=', 'revaluating')]"/>
                 <filter string="Done" name="filter_done" domain="[('state', '=', 'done')]"/>
+                <filter string="Error" name="filter_error" domain="[('state', '=', 'error')]"/>
                 <filter string="Cancelled" name="filter_cancel" domain="[('state', '=', 'cancel')]"/>
                 <filter string="SLV Changed" name="filter_slv_changed" domain="[('slv_changed', '=', True)]"/>
                 <field name="product_id" string="Product"/>


### PR DESCRIPTION
The repair tool works one record at a time. Repairing a database means opening every recompute and pressing the two buttons on each one, which on a real run is hundreds of records.

## What changes

The list view gets both actions in its header, acting on the selection. They are not symmetric, because what they cost is not symmetric.

**Compute lines** does not touch the layers or their journal entries — all it writes are the recompute's own proposed lines — so the header button does it in the request, delegating to the single record method. Takes `draft`, `in_process`, `no_change` and `error`.

**Revaluate** does write, so the header button applies nothing however many records are selected. It moves them to a new `revaluating` state and a scheduled action applies them one by one in the background. Queueing is a state write, so the size of the queue does not matter and no request ever holds a revaluation. Takes `in_process` only.

Cancelling a record before the cron reaches it takes it out of the queue, which the cron honours by re-reading the state rather than trusting the list it read when it started.

## Why the cron uses a time budget, and why it is small

What must not be exceeded is the worker's `--limit-time-real-cron`, which by default falls back to `--limit-time-real`, 120 seconds. A fixed number of records does not protect that: revaluating a product with 500 layers does not cost what one with 5 costs.

The budget is per *invocation*, not per thread: `ir_cron._run_job` re-invokes the callback up to `MAX_BATCH_PER_CRON_JOB` (10) times in a row while work remains, committing between them. Ten invocations have to fit inside the worker's limit, so the budget is on the order of a tenth of it.

Progress is reported per record through `_notify_progress`, which does two things: a cut only counts as a failure when nothing was done, and a run leaving `remaining > 0` is relaunched immediately instead of waiting for the interval. A queue of any size drains back to back.

The cron iterates ids and browses one at a time — iterating the recordset would pull every queued record's lines into the cache for a run that only reaches a handful — releases the cache between records, and applies each one as superuser in its own company, since the cron's user has no reason to be enabled in the company where the product is valued.

## Failures

Each record of a batch is applied inside its own savepoint, on both paths, so one that fails rolls back alone and the batch carries on. It lands in a new `error` state with the reason stored on the record and shown on the form. Only `UserError` and its subclasses are caught — everything the flow itself raises; an infrastructure failure is not one of those and propagates on purpose, since parking it in a state nothing retries would pass it off as a definitive rejection.

It is not retried automatically: the usual reason is a correction that starts before the fiscal lock date, which retrying does not fix. To retry, compute the lines again (which clears the reason) and revaluate.

**Revaluating now requires computed lines.** Without them there is nothing computed and the final amounts are zero, so applying would write a zero cost on the product without leaving a trace on any layer. That became reachable the moment a failed *compute* could land in a state the Revaluate button offered, so the guard is on the method and the state is excluded from the queue.

## Note for review

The records in a run share the cron's transaction — the savepoint gives per record atomicity, not a commit per record. A killed run therefore redoes its own work rather than leaving part of it applied, which seemed the safer trade. Happy to commit per record instead if you prefer the locks released as it goes.

Compute has no queue, per the ask. It is still O(history) per product in a single request, so a large selection of long-history products can run past the request timeout and save nothing; the README says so rather than promising otherwise. If it turns out to bite, the same budgeted queue would cover it.

## Test plan

`stock_currency_valuation_recompute` tests, 10 passed:

- `test_compute_lines_multi_processes_every_selected_record` — both selected records get recomputed, not only the first.
- `test_compute_lines_multi_isolates_the_record_that_fails` — a product valued by lot (unsupported) lands in `error` with its reason while the healthy record in the same selection is still computed.
- `test_queue_revaluation_has_no_limit` — 35 records queue without complaint.
- `test_cron_drains_the_queue` — a product whose cost drifted from its layers is computed, queued, and reaches `done` through the cron.
- `test_cron_respects_a_record_taken_out_of_the_queue` — a record cancelled after queueing stays `cancel` and is not applied, while the other one still reaches `done`.
- `test_a_record_without_lines_cannot_be_revaluated` — the zero-cost path is refused.
- `test_a_failed_compute_cannot_be_queued_for_revaluation` — an `error` record with no lines cannot be queued.
- `test_a_retry_that_works_clears_the_previous_error` — a successful compute clears a stale reason.
- `test_queue_revaluation_skips_records_already_applied` — a `done` record cannot be queued again.
- `test_recompute_detects_out_valued_with_stale_cost` — the pre-existing one, now sharing the drift fixture.

Manually: filter the list by In Process, tick a few hundred records, press Revaluate, and watch them move from Revaluating to Done as the cron drains the queue.