### PR TITLE
[ADD] stock_ux: invariant battery for the stock test suites

### DIFF
--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,1 +1,8 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import invariants
+from . import common
 from . import test_mto_warehouse_propagation
+from . import test_invariants

--- a/stock_ux/tests/common.py
+++ b/stock_ux/tests/common.py
@@ -1,0 +1,117 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Configuración de escenario de las suites de stock_ux.
+
+Las tres categorías de datos, separadas a propósito:
+
+- **Entorno** (de la base): la compañía y su almacén. Recrearlos es caro y no
+  aporta señal.
+- **Configuración del escenario** (la crea el test): los tipos de operación con
+  sus banderas, que es lo que decide qué se está probando. Se crean propios
+  para no depender de cómo esté configurada la base.
+- **Documentos** (siempre los crea el test): pickings, moves y quants.
+
+Ningún assert se apoya en registros que el test no haya creado.
+"""
+
+from odoo.tests import TransactionCase, tagged
+
+from .invariants import StockUxInvariants
+
+
+@tagged("post_install", "-at_install")
+class StockUxCommon(TransactionCase, StockUxInvariants):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.company.id)], limit=1)
+        cls.stock_location = cls.warehouse.lot_stock_id
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+
+        cls.partner = cls.env["res.partner"].create({"name": "Cliente UX de prueba"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Producto UX almacenable", "is_storable": True, "list_price": 100.0}
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {"name": "Producto UX almacenable B", "is_storable": True, "list_price": 50.0}
+        )
+
+        # Tipos de operación propios: las banderas son lo que decide qué se prueba,
+        # así que no se heredan de la configuración de la base.
+        cls.out_type = cls._crear_picking_type(cls.warehouse.out_type_id, "UX Salida")
+        cls.in_type = cls._crear_picking_type(cls.warehouse.in_type_id, "UX Recepción")
+        cls.int_type = cls._crear_picking_type(cls.warehouse.int_type_id, "UX Interna")
+
+    @classmethod
+    def _crear_picking_type(cls, plantilla, nombre):
+        """Copia un tipo del almacén y apaga todas las banderas de stock_ux.
+
+        Cada test enciende explícitamente la que va a probar: así el escenario
+        dice qué se está probando, en vez de heredarlo de la base.
+        """
+        return plantilla.copy(
+            {
+                "name": nombre,
+                "sequence_code": nombre.replace(" ", "")[:5].upper(),
+                "block_additional_quantity": False,
+                "block_picking_deletion": False,
+                "block_manual_lines": False,
+                "restrict_number_package": False,
+                "number_of_packages": False,
+            }
+        )
+
+    @classmethod
+    def _poner_stock(cls, product, cantidad, location=None):
+        """Deja stock disponible del producto en la ubicación indicada."""
+        cls.env["stock.quant"]._update_available_quantity(product, location or cls.stock_location, cantidad)
+
+    def _crear_picking(self, picking_type=None, lineas=None, location=None, location_dest=None):
+        """Crea un picking con sus moves. `lineas` es una lista de (producto, cantidad)."""
+        picking_type = picking_type or self.out_type
+        lineas = lineas if lineas is not None else [(self.product, 10.0)]
+        origen = location or picking_type.default_location_src_id or self.stock_location
+        destino = location_dest or picking_type.default_location_dest_id or self.customer_location
+        return self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": picking_type.id,
+                "location_id": origen.id,
+                "location_dest_id": destino.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": producto.id,
+                            "product_uom_qty": cantidad,
+                            "product_uom": producto.uom_id.id,
+                            "location_id": origen.id,
+                            "location_dest_id": destino.id,
+                        },
+                    )
+                    for producto, cantidad in lineas
+                ],
+            }
+        )
+
+    def _crear_usuario(self, nombre, grupos):
+        """Usuario interno con los grupos indicados (lista de xml ids)."""
+        return (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": nombre,
+                    "login": "%s@ux.test" % nombre.lower().replace(" ", "."),
+                    "email": "%s@ux.test" % nombre.lower().replace(" ", "."),
+                    "company_id": self.company.id,
+                    "company_ids": [(6, 0, self.company.ids)],
+                    "group_ids": [(6, 0, [self.env.ref(g).id for g in grupos])],
+                }
+            )
+        )

--- a/stock_ux/tests/invariants.py
+++ b/stock_ux/tests/invariants.py
@@ -1,0 +1,197 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Batería de invariantes de stock_ux.
+
+Propiedades que tienen que valer después de *cualquier* operación de stock,
+no lo que un escenario puntual fue a buscar. Se llaman después de cada
+operación del test, y corren en todas las suites que hereden este mixin.
+
+stock_ux es la raíz de la cadena Adhoc de stock (depende solo de core), así
+que la batería vive acá: los 19 módulos propios que lo declaran en `depends`
+la heredan sin copiarla.
+
+Reglas de la batería (no negociables):
+
+1. No tiene interruptores para saltear invariantes. Si un escenario
+   legítimamente viola una, la excepción se declara en el test, a la vista.
+2. Cada invariante tiene test propio en los dos sentidos: que no moleste a
+   una operación sana, y que detecte la operación defectuosa.
+"""
+
+from odoo.tools import float_compare, float_is_zero
+
+
+class StockUxInvariants:
+    """Mixin de invariantes. Se hereda junto a TransactionCase."""
+
+    def _uom_precision(self):
+        return self.env["decimal.precision"].precision_get("Product Unit of Measure")
+
+    def assert_sin_moves_extra(self, picking, esperado_por_producto):
+        """El picking no gana movimientos que nadie pidió.
+
+        Es la propiedad que fallaron los tickets de "contraentrega fantasma"
+        (123822, 124773, 124957, 125936, 126226): al cancelar el remanente, el
+        move negativo no netea y en vez de cancelar el pendiente queda un
+        movimiento nuevo, en sentido contrario, que nadie pidió.
+
+        :param esperado_por_producto: dict {product: cantidad demandada viva}
+        """
+        precision = self._uom_precision()
+        vivos = picking.move_ids.filtered(lambda m: m.state != "cancel")
+        # Ningún move vivo puede quedar en cantidad negativa: un negativo que
+        # sobrevive es, exactamente, el movimiento que nadie pidió.
+        negativos = vivos.filtered(lambda m: float_compare(m.product_uom_qty, 0.0, precision_digits=precision) < 0)
+        self.assertFalse(
+            negativos,
+            "Quedaron moves en cantidad negativa (el neteo no ocurrió): %s"
+            % negativos.mapped(lambda m: "%s: %s" % (m.product_id.display_name, m.product_uom_qty)),
+        )
+        # La demanda viva por producto es exactamente la esperada, ni más ni menos.
+        real = {}
+        for move in vivos:
+            real[move.product_id] = real.get(move.product_id, 0.0) + move.product_uom_qty
+        self.assertEqual(
+            set(real.keys()),
+            set(esperado_por_producto.keys()),
+            "Los productos con demanda viva no son los esperados",
+        )
+        for product, cantidad in esperado_por_producto.items():
+            self.assertEqual(
+                float_compare(real[product], cantidad, precision_digits=precision),
+                0,
+                "La demanda viva de %s es %s y se esperaba %s" % (product.display_name, real[product], cantidad),
+            )
+
+    def assert_cantidad_no_supera_demanda(self, picking):
+        """Con el tipo de operación bloqueando adicionales, ninguna cantidad
+        transferida supera la demanda inicial."""
+        if not picking.picking_type_id.block_additional_quantity:
+            return
+        precision = self._uom_precision()
+        for move in picking.move_ids.filtered(lambda m: m.state != "cancel"):
+            # Los ajustes de inventario están fuera del alcance del bloqueo (ver _check_quantity).
+            if move.location_dest_usage == "inventory":
+                continue
+            self.assertLessEqual(
+                float_compare(move.quantity, move.product_uom_qty, precision_digits=precision),
+                0,
+                "%s transfiere %s con demanda inicial %s"
+                % (move.product_id.display_name, move.quantity, move.product_uom_qty),
+            )
+
+    def assert_sin_disponible_negativo(self, picking):
+        """Ninguna ubicación interna del origen queda con disponible negativo
+        para los productos del picking."""
+        productos = picking.move_ids.product_id.filtered("is_storable")
+        if not productos:
+            return
+        precision = self._uom_precision()
+        ubicaciones = self.env["stock.location"].search(
+            [
+                ("id", "child_of", picking.location_id.id),
+                ("usage", "=", "internal"),
+                ("company_id", "in", [picking.company_id.id, False]),
+            ]
+        )
+        if not ubicaciones:
+            return
+        quants = self.env["stock.quant"].search(
+            [("product_id", "in", productos.ids), ("location_id", "in", ubicaciones.ids)]
+        )
+        negativos = quants.filtered(lambda q: float_compare(q.available_quantity, 0.0, precision_digits=precision) < 0)
+        self.assertFalse(
+            negativos,
+            "Quedó disponible negativo en: %s"
+            % negativos.mapped(
+                lambda q: "%s @ %s: %s" % (q.product_id.display_name, q.location_id.name, q.available_quantity)
+            ),
+        )
+
+    def assert_lineas_con_descripcion(self, picking):
+        """Toda línea de operación del picking tiene descripción.
+
+        stock_ux la completa en el create de stock.move.line con el idioma del
+        contacto del picking; una línea sin descripción sale en blanco en el
+        remito.
+        """
+        sin_descripcion = picking.move_line_ids.filtered(lambda l: not l.description_picking)
+        self.assertFalse(
+            sin_descripcion,
+            "Líneas de operación sin descripción: %s" % sin_descripcion.mapped("product_id.display_name"),
+        )
+
+    def assert_estados_consistentes(self, picking):
+        """Un picking validado deja todos sus moves en hecho o cancelado, y
+        ningún move hecho en cantidad cero."""
+        if picking.state != "done":
+            return
+        precision = self._uom_precision()
+        colgados = picking.move_ids.filtered(lambda m: m.state not in ("done", "cancel"))
+        self.assertFalse(
+            colgados,
+            "El picking está validado y quedaron moves en otro estado: %s"
+            % colgados.mapped(lambda m: "%s: %s" % (m.product_id.display_name, m.state)),
+        )
+        en_cero = picking.move_ids.filtered(
+            lambda m: m.state == "done" and float_is_zero(m.quantity, precision_digits=precision)
+        )
+        self.assertFalse(
+            en_cero,
+            "Moves hechos en cantidad cero: %s" % en_cero.mapped("product_id.display_name"),
+        )
+
+    def assert_sin_pickings_contraflujo(self, pickings, codigos_esperados):
+        """El documento no genera pickings en sentido contrario al suyo.
+
+        Las invariantes de arriba miran un picking por vez; esta mira el
+        *conjunto* que un documento generó, que es donde vive la contraentrega:
+        el picking pendiente no se cancela y aparece uno nuevo, de tipo
+        contrario, que nadie pidió (121400, 122299, 123822, 124773, 125936,
+        126226).
+
+        Un picking fuera del flujo esperado solo es legítimo cuando es una
+        devolución, y Odoo la marca poniendo ``origin_returned_move_id`` en
+        todos sus moves.
+
+        ``codigos_esperados`` es el parámetro que declara cada módulo
+        consumidor: la forma de la invariante se comparte, el conjunto no.
+        Una venta declara ``("outgoing", "internal")``; una compra,
+        ``("incoming", "internal")``.
+        """
+        contraflujo = self.env["stock.picking"].browse()
+        for picking in pickings.filtered(lambda p: p.state != "cancel"):
+            if picking.picking_type_id.code in codigos_esperados:
+                continue
+            if any(not move.origin_returned_move_id for move in picking.move_ids):
+                contraflujo |= picking
+        self.assertFalse(
+            contraflujo,
+            "Pickings fuera del flujo esperado %s que no son devoluciones: %s"
+            % (
+                tuple(codigos_esperados),
+                contraflujo.mapped(lambda p: "%s (%s)" % (p.name, p.picking_type_id.code)),
+            ),
+        )
+
+    def assert_bateria(self, picking, esperado_por_producto=None):
+        """Corre la batería entera. Es lo que se llama después de cada operación."""
+        if esperado_por_producto is not None:
+            self.assert_sin_moves_extra(picking, esperado_por_producto)
+        self.assert_cantidad_no_supera_demanda(picking)
+        self.assert_sin_disponible_negativo(picking)
+        self.assert_lineas_con_descripcion(picking)
+        self.assert_estados_consistentes(picking)
+
+    def assert_bateria_documento(self, pickings, codigos_esperados):
+        """Corre la batería sobre todos los pickings que generó un documento.
+
+        Es el punto de entrada de los módulos cuyo documento genera más de un
+        picking (una venta, una compra): verifica primero el conjunto y después
+        cada picking por separado.
+        """
+        self.assert_sin_pickings_contraflujo(pickings, codigos_esperados)
+        for picking in pickings:
+            self.assert_bateria(picking)

--- a/stock_ux/tests/test_invariants.py
+++ b/stock_ux/tests/test_invariants.py
@@ -1,0 +1,150 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""La batería, probada en los dos sentidos.
+
+Cada invariante se verifica dos veces: que no moleste a una operación sana, y
+que detecte la operación defectuosa que existe para atajar. Sin la segunda no
+sabemos si la invariante mira.
+"""
+
+from odoo.tests import Form
+
+from .common import StockUxCommon
+
+
+class TestInvariants(StockUxCommon):
+    def setUp(self):
+        super().setUp()
+        self._poner_stock(self.product, 50.0)
+        self.picking = self._crear_picking(lineas=[(self.product, 10.0)])
+        self.picking.action_confirm()
+
+    # --- I1: el picking no gana movimientos que nadie pidió --------------
+
+    def test_sin_moves_extra_no_molesta_a_una_operacion_sana(self):
+        # Un picking con su demanda intacta pasa la invariante
+        self.assert_sin_moves_extra(self.picking, {self.product: 10.0})
+
+    def test_sin_moves_extra_detecta_el_negativo_que_sobrevive(self):
+        # Un move negativo que no neteó es la contraentrega fantasma
+        self.picking.move_ids[0].copy({"product_uom_qty": -4.0})
+        with self.assertRaises(AssertionError):
+            self.assert_sin_moves_extra(self.picking, {self.product: 10.0})
+
+    def test_sin_moves_extra_detecta_la_demanda_que_no_cierra(self):
+        # Un move extra del mismo producto infla la demanda viva
+        self.picking.move_ids[0].copy({"product_uom_qty": 3.0})
+        with self.assertRaises(AssertionError):
+            self.assert_sin_moves_extra(self.picking, {self.product: 10.0})
+
+    # --- I2: ninguna cantidad supera la demanda inicial -------------------
+
+    def test_cantidad_no_supera_demanda_no_molesta_a_una_operacion_sana(self):
+        # Transferir exactamente lo demandado pasa la invariante
+        self.picking.picking_type_id.block_additional_quantity = True
+        self.picking.move_ids.quantity = 10.0
+        self.assert_cantidad_no_supera_demanda(self.picking)
+
+    def test_cantidad_no_supera_demanda_detecta_el_exceso(self):
+        # La cantidad se carga con el bloqueo apagado y se enciende después:
+        # así el estado defectuoso existe sin pasar por el constrain del módulo
+        self.picking.move_ids.quantity = 12.0
+        self.picking.picking_type_id.block_additional_quantity = True
+        with self.assertRaises(AssertionError):
+            self.assert_cantidad_no_supera_demanda(self.picking)
+
+    # --- I3: ninguna ubicación interna queda con disponible negativo ------
+
+    def test_sin_disponible_negativo_no_molesta_a_una_operacion_sana(self):
+        self.assert_sin_disponible_negativo(self.picking)
+
+    def test_sin_disponible_negativo_detecta_el_quant_en_rojo(self):
+        # Dejamos la ubicación de origen en rojo para el producto del picking
+        self._poner_stock(self.product, -60.0)
+        with self.assertRaises(AssertionError):
+            self.assert_sin_disponible_negativo(self.picking)
+
+    # --- I4: toda línea de operación tiene descripción --------------------
+
+    def test_lineas_con_descripcion_no_molesta_a_una_operacion_sana(self):
+        self.picking.action_assign()
+        self.assertTrue(self.picking.move_line_ids, "El escenario necesita líneas reservadas")
+        self.assert_lineas_con_descripcion(self.picking)
+
+    def test_lineas_con_descripcion_detecta_la_linea_en_blanco(self):
+        self.picking.action_assign()
+        self.picking.move_line_ids[0].description_picking = False
+        with self.assertRaises(AssertionError):
+            self.assert_lineas_con_descripcion(self.picking)
+
+    # --- I5: el picking validado deja estados consistentes ----------------
+
+    def test_estados_consistentes_no_molesta_a_una_operacion_sana(self):
+        self.picking.action_assign()
+        self.picking.move_ids.quantity = 10.0
+        self.picking.button_validate()
+        self.assertEqual(self.picking.state, "done")
+        self.assert_estados_consistentes(self.picking)
+
+    def test_estados_consistentes_detecta_el_move_hecho_en_cero(self):
+        self.picking.action_assign()
+        self.picking.move_ids.quantity = 10.0
+        self.picking.button_validate()
+        # Vaciamos la línea de un move ya hecho: queda un move done sin cantidad
+        self.picking.move_line_ids.write({"quantity": 0.0})
+        with self.assertRaises(AssertionError):
+            self.assert_estados_consistentes(self.picking)
+
+    def test_estados_consistentes_no_verifica_un_picking_sin_validar(self):
+        # La invariante solo habla de pickings validados: sobre uno abierto no opina
+        self.assertNotEqual(self.picking.state, "done")
+        self.assert_estados_consistentes(self.picking)
+
+    # --- I6: el documento no genera pickings en sentido contrario ---------
+
+    VENTA = ("outgoing", "internal")
+
+    def test_sin_pickings_contraflujo_no_molesta_a_una_devolucion_genuina(self):
+        # Una devolución real es un picking de entrada legítimo: no es contraflujo
+        self.picking.action_assign()
+        self.picking.move_ids.quantity = 10.0
+        self.picking.button_validate()
+        wizard = Form(
+            self.env["stock.return.picking"].with_context(
+                active_id=self.picking.id, active_ids=self.picking.ids, active_model="stock.picking"
+            )
+        ).save()
+        # El wizard nace en cantidad cero: sin esto no hay nada que devolver
+        wizard.product_return_moves.quantity = 10.0
+        devolucion = self.env["stock.picking"].browse(wizard.action_create_returns()["res_id"])
+        self.assertEqual(devolucion.picking_type_id.code, "incoming", "El escenario necesita una devolución entrante")
+
+        self.assert_sin_pickings_contraflujo(self.picking | devolucion, self.VENTA)
+
+    def test_sin_pickings_contraflujo_detecta_la_contraentrega(self):
+        # Una recepción que nadie devolvió: la forma exacta de la contraentrega
+        contraentrega = self._crear_picking(picking_type=self.in_type, lineas=[(self.product, 4.0)])
+        self.assertFalse(contraentrega.move_ids.origin_returned_move_id)
+
+        with self.assertRaises(AssertionError):
+            self.assert_sin_pickings_contraflujo(self.picking | contraentrega, self.VENTA)
+
+    def test_bateria_documento_recorre_el_conjunto_y_cada_picking(self):
+        # El runner de documento verifica el conjunto y después picking por picking
+        self.assert_bateria_documento(self.picking, self.VENTA)
+        contraentrega = self._crear_picking(picking_type=self.in_type, lineas=[(self.product, 4.0)])
+        with self.assertRaises(AssertionError):
+            self.assert_bateria_documento(self.picking | contraentrega, self.VENTA)
+
+    # --- la batería completa ----------------------------------------------
+
+    def test_bateria_completa_sobre_una_entrega_sana(self):
+        # Una entrega normal, de punta a punta, no viola ninguna invariante
+        self.assert_bateria(self.picking, {self.product: 10.0})
+        self.picking.action_assign()
+        self.assert_bateria(self.picking, {self.product: 10.0})
+        self.picking.move_ids.quantity = 10.0
+        self.picking.button_validate()
+        self.assert_bateria(self.picking, {self.product: 10.0})


### PR DESCRIPTION
## Qué hace

Agrega una batería de invariantes para las suites de tests de stock, en `stock_ux/tests/`. **No cambia comportamiento de producto**: es infraestructura de testing.

Una invariante es una propiedad que tiene que valer después de *cualquier* operación, no lo que un escenario puntual fue a buscar. El caso que lo motiva: un test que verifica que un número está bien no ve lo que quedó roto **al lado** — una línea de más, un estado intermedio, un movimiento que nadie pidió. Los bugs que llegan como incidentes casi nunca son "el número está mal", son "el número está bien, pero al lado quedó algo roto".

## Por qué en `stock_ux`

Es la raíz de la cadena Adhoc de stock (depende solo de core). Los módulos que lo declaran en `depends` heredan la batería sin copiarla. Copias por módulo se pudren: alguien relaja una para que su test pase y nadie lo ve.

## Invariantes

| Invariante | Qué verifica |
|---|---|
| `assert_sin_moves_extra` | El picking no gana movimientos que nadie pidió |
| `assert_cantidad_no_supera_demanda` | Con el tipo de operación bloqueando adicionales, ninguna cantidad transferida supera la demanda inicial |
| `assert_sin_disponible_negativo` | Ninguna ubicación interna del origen queda con disponible negativo |
| `assert_lineas_con_descripcion` | Toda línea de operación tiene descripción (si no, sale en blanco en el remito) |
| `assert_estados_consistentes` | Un picking validado deja todos sus moves en hecho o cancelado, y ninguno hecho en cantidad cero |
| `assert_sin_pickings_contraflujo` | El documento no genera pickings en sentido contrario al suyo |

La última está **parametrizada** (`codigos_esperados`): la forma se comparte, el conjunto lo declara cada módulo consumidor — una venta declara `("outgoing", "internal")`; una compra, `("incoming", "internal")`. Sin ese parámetro marcaría como bug toda recepción legítima en el flujo de compras.

`assert_bateria` corre la batería sobre un picking; `assert_bateria_documento` sobre el conjunto de pickings que generó un documento, que es el punto de entrada para los módulos cuyo documento genera más de un picking.

## Decisiones de diseño

- **Sin interruptores para saltear invariantes.** Un escenario que legítimamente viola una declara la excepción en el test, a la vista y con el motivo al lado. Una batería con condicionales adentro se vuelve el lugar donde se entierran los casos que nadie verifica.
- **Cada invariante se prueba en los dos sentidos**: que no moleste a una operación sana, y que detecte la operación defectuosa que existe para atajar. Sin la segunda no hay evidencia de que la invariante mire algo.
- **Las tres categorías de datos, separadas a propósito**: entorno (de la base), configuración del escenario (la crea el test — los tipos de operación con sus banderas, que es lo que decide qué se prueba) y documentos (siempre los crea el test). Ningún assert se apoya en registros que el test no haya creado.
- **La batería concentra riesgo** y se asume: si tiene un error, no falla un test, quedan todas las suites en verde sin verificar nada. Por eso los tests en los dos sentidos son parte del entregable, no un extra.

## Test plan

Base Odoo 19 limpia con `sale_stock_ux` instalado.

```
odoo -d <base> -u stock_ux --test-tags /stock_ux --stop-after-init
EXIT=0
odoo.tests.stats:  stock_ux: 22 tests 9.61s 3060 queries
odoo.tests.result: 0 failed, 0 error(s) of 18 tests
```

Sin warnings de addons (runbot los trata como error).

**Rojo demostrado.** Neutralizando la condición de `assert_sin_pickings_contraflujo` (`if any(not move.origin_returned_move_id ...)` → `if False`):

```
EXIT=1
FAIL: TestInvariants.test_bateria_documento_recorre_el_conjunto_y_cada_picking
FAIL: TestInvariants.test_sin_pickings_contraflujo_detecta_la_contraentrega
2 failed, 0 error(s) of 16 tests
```

Fallan exactamente los dos tests que dicen detectarla, y ninguno de los otros. Código restaurado y verde de nuevo.

## Qué sigue

Las suites que consumen esta batería van en PRs aparte, por módulo. El primero es `sale_stock_ux`, que además suma dos invariantes propias (las que leen campos que ese módulo define).

Task: https://www.adhoc.inc/odoo/project.task/72661
