### PR TITLE
[IMP] stock_ux, stock_picking_state: add field help

### DIFF
--- a/stock_picking_state/__manifest__.py
+++ b/stock_picking_state/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Picking State",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_picking_state/i18n/es.po
+++ b/stock_picking_state/i18n/es.po
@@ -124,6 +124,17 @@ msgid "State Detail"
 msgstr "Subestado"
 
 #. module: stock_picking_state
+#: model:ir.model.fields,help:stock_picking_state.field_stock_picking__state_detail_id
+msgid ""
+"Configurable sub-status within the transfer status (e.g. within 'Ready': 'In "
+"preparation', 'In control'). It is filtered by the transfer status and the "
+"operation type."
+msgstr ""
+"Sub-estado configurable dentro del estado del traslado (por ej. dentro de "
+"'Listo': 'En preparación', 'En control'). Se filtra según el estado y el tipo "
+"de operación."
+
+#. module: stock_picking_state
 #: model:ir.model.fields,field_description:stock_picking_state.field_stock_picking_state_detail__state
 msgid "Status"
 msgstr "Estado"

--- a/stock_picking_state/i18n/stock_picking_state.pot
+++ b/stock_picking_state/i18n/stock_picking_state.pot
@@ -119,6 +119,14 @@ msgid "State Detail"
 msgstr ""
 
 #. module: stock_picking_state
+#: model:ir.model.fields,help:stock_picking_state.field_stock_picking__state_detail_id
+msgid ""
+"Configurable sub-status within the transfer status (e.g. within 'Ready': 'In "
+"preparation', 'In control'). It is filtered by the transfer status and the "
+"operation type."
+msgstr ""
+
+#. module: stock_picking_state
 #: model:ir.model.fields,field_description:stock_picking_state.field_stock_picking_state_detail__state
 msgid "Status"
 msgstr ""

--- a/stock_picking_state/models/stock_picking.py
+++ b/stock_picking_state/models/stock_picking.py
@@ -15,6 +15,9 @@ class StockPicking(models.Model):
         tracking=True,
         index=True,
         copy=False,
+        help="Configurable sub-status within the transfer status (e.g. within 'Ready': "
+        "'In preparation', 'In control'). It is filtered by the transfer status and "
+        "the operation type.",
     )
 
     @api.constrains("state")

--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.18.0",
+    "version": "19.0.1.18.1",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/i18n/es.po
+++ b/stock_ux/i18n/es.po
@@ -868,6 +868,15 @@ msgid "Reviewed"
 msgstr "Revisado"
 
 #. module: stock_ux
+#: model:ir.model.fields,help:stock_ux.field_stock_warehouse_orderpoint__reviewed
+msgid ""
+"Marks the replenishment line as reviewed. It is set automatically when the "
+"quantity to order is adjusted and cleared when the replenishment is generated."
+msgstr ""
+"Marca la línea de reabastecimiento como revisada. Se activa automáticamente al "
+"ajustar la cantidad a pedir y se limpia al generar el reabastecimiento."
+
+#. module: stock_ux
 #: model:ir.model.fields,field_description:stock_ux.field_stock_warehouse_orderpoint__rotation
 msgid "Rotation"
 msgstr "Rotación"

--- a/stock_ux/i18n/stock_ux.pot
+++ b/stock_ux/i18n/stock_ux.pot
@@ -824,6 +824,13 @@ msgid "Reviewed"
 msgstr ""
 
 #. module: stock_ux
+#: model:ir.model.fields,help:stock_ux.field_stock_warehouse_orderpoint__reviewed
+msgid ""
+"Marks the replenishment line as reviewed. It is set automatically when the "
+"quantity to order is adjusted and cleared when the replenishment is generated."
+msgstr ""
+
+#. module: stock_ux
 #: model:ir.model.fields,field_description:stock_ux.field_stock_warehouse_orderpoint__rotation
 msgid "Rotation"
 msgstr ""

--- a/stock_ux/models/stock_warehouse_orderpoint.py
+++ b/stock_ux/models/stock_warehouse_orderpoint.py
@@ -46,7 +46,10 @@ class StockWarehouseOrderpoint(models.Model):
     qty_multiple = fields.Float(tracking=True)
     location_id = fields.Many2one(tracking=True)
     product_id = fields.Many2one(tracking=True)
-    reviewed = fields.Boolean()
+    reviewed = fields.Boolean(
+        help="Marks the replenishment line as reviewed. It is set automatically when the "
+        "quantity to order is adjusted and cleared when the replenishment is generated.",
+    )
 
     @api.depends("product_id", "location_id")
     def _compute_rotation(self):


### PR DESCRIPTION
## What
Add `help` (English in code, Spanish in `i18n/es.po`) to two client-facing fields:
- `reviewed` (`stock.warehouse.orderpoint`, `stock_ux`): flag toggled automatically when the quantity to order is adjusted and cleared on replenishment.
- `state_detail_id` (`stock.picking`, `stock_picking_state`): configurable sub-status within the transfer status (e.g. within "Ready": "In preparation", "In control").

## Why
The behavior of both fields is not conveyed by the label. Part of R&D task 71629, Services & Supply Chain team batch (same branch `19.0-t-71629-les` as the sibling PRs, single runbot build).

## Test plan
- Replenishment / reordering rules → the reviewed column tooltip.
- Transfer (picking) → the state detail field shows its tooltip.
- Base in `es_AR`/`es_419`: tooltips render in Spanish.

Tarea: https://www.adhoc.inc/odoo/project.task/71629