### PR TITLE
[FIX] stock_voucher: batch voucher number satisfies the picking requirement

### DIFF
--- a/stock_voucher/models/stock_picking.py
+++ b/stock_voucher/models/stock_picking.py
@@ -149,9 +149,20 @@ class StockPicking(models.Model):
                 if picking.picking_type_id.restrict_number_package and not picking.number_of_packages > 0:
                     raise UserError(_("The number of packages can not be 0"))
             batch_exists = "batch_id" in picking._fields and picking.batch_id
+            # el lote numera los remitos después de validar, pero sólo en su
+            # rama incoming: fuera de ahí su número no se usa y el traslado
+            # tiene que seguir exigiendo el suyo
+            batch_numbers_voucher = (
+                batch_exists and batch_exists.picking_type_code == "incoming" and batch_exists.voucher_number
+            )
             if picking.book_required and not picking.book_id and not batch_exists:
                 raise UserError(_("You must select a Voucher Book"))
-            elif not picking.location_id.usage == "customer" and picking.voucher_required and not picking.voucher_ids:
+            elif (
+                not picking.location_id.usage == "customer"
+                and picking.voucher_required
+                and not picking.voucher_ids
+                and not batch_numbers_voucher
+            ):
                 raise UserError(_("You must set stock voucher numbers"))
         return True
 

--- a/stock_voucher/tests/__init__.py
+++ b/stock_voucher/tests/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import test_stock_picking_voucher
 from . import test_stock_book
+from . import test_stock_picking

--- a/stock_voucher/tests/test_stock_picking.py
+++ b/stock_voucher/tests/test_stock_picking.py
@@ -1,0 +1,32 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestVoucherRequired(TransactionCase):
+    def test_batch_voucher_number(self):
+        """Alcanza sólo si el lote lo va a usar."""
+        if "stock.picking.batch" not in self.env:
+            self.skipTest("stock_picking_batch no instalado")
+        picking_type = self.env.ref("stock.picking_type_in")
+        picking_type.voucher_required = True
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.env.ref("stock.stock_location_stock").id,
+            }
+        )
+        batch = self.env["stock.picking.batch"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "picking_ids": [(6, 0, picking.ids)],
+                "voucher_number": "0001-00000123",
+            }
+        )
+        picking.do_stock_voucher_transfer_check()
+
+        batch.voucher_number = False
+        with self.assertRaises(UserError):
+            picking.do_stock_voucher_transfer_check()


### PR DESCRIPTION
Closes the regression reported in https://www.adhoc.inc/odoo/helpdesk.ticket/126542

### Problem

Validating a batch transfer of receptions whose operation type has **"Voucher Required?"** raises `You must set stock voucher numbers`, even though the voucher number is already filled in on the batch. Every reception through *Batch Transfers* is blocked on the affected bases.

### Cause

The core `stock.picking.batch.action_done()` ends in `pickings.button_validate()`. The `stock_voucher` override of `button_validate` runs `do_stock_voucher_transfer_check()` **before** the super, and that check demands `voucher_ids` on every picking whose type has `voucher_required`.

Until e1a2d10b the batch created those `stock.picking.voucher` records **before** calling the super, so the check found them. That commit deferred the numbering to **after** validation — on purpose, so an aborted validation stops leaving numbered records on pickings that never reached `done` — and the check was left with nothing to look at.

The `book_required` branch of that same `if` already had a batch escape hatch (`batch_exists`); the `voucher_required` branch never did.

Reverting is not an option: the two behaviours are mutually exclusive, and each has a regression test that fails without the other's fix.

### Approach

The guard stands down for the one case the batch covers: an **incoming** batch carrying a number, which `action_done()` stamps on every picking right after validating it. One condition in the same `if`, next to the `batch_exists` shortcut the `book_required` branch already uses.

Both halves of that condition matter. Reusing the plain `batch_exists` shortcut, or checking only that a number is present, lets a transfer validate with no voucher at all — an outgoing batch keeps a leftover `voucher_number` when its operation type is switched, and outside the incoming branch nothing numbers the picking. Verified: with either weaker condition a `voucher_required` transfer reaches `done` with an empty `voucher_ids`.

`voucher_number` is safe to read here without a `_fields` check: `stock_batch_picking_ux` is `auto_install` on top of `stock_ux`, `stock_voucher` and `stock_picking_batch`, so wherever `batch_id` exists on a picking and this module's code is running, all three are installed and the field is there.

### Known path left alone

The outgoing branch of `action_done()` (`auto_print_delivery_slip` plus a book) defers its numbering the same way and would hit the same guard. No operation type with `voucher_required` and `code != incoming` exists on the bases already running this code, so it is left untouched instead of guessing which of the two paths is the correct one. Happy to extend the condition if a reviewer knows the intended behaviour there.

### Test plan

One test in `stock_voucher/tests/test_stock_picking.py`, calling `do_stock_voucher_transfer_check()` on a reception in a batch that carries a number (passes) and on the same one with the number cleared (blocks). Tagged `post_install` so the batch fields are in the registry by the time it runs, and it skips where `stock_picking_batch` is not installed.

```
-u stock_voucher,stock_batch_picking_ux --test-tags '/stock_voucher,/stock_batch_picking_ux,/stock_voucher_ux'
0 failed, 0 error(s) of 7 tests
```

Discriminates, checked one condition at a time:

| Code under test | Result |
|---|---|
| Without the fix | the test errors with `UserError: You must set stock voucher numbers` |
| Condition reusing plain `batch_exists` | the blocking assertion fails |
| Condition checking only `voucher_number` | an outgoing batch with a leftover number reaches `done` with an empty `voucher_ids` |
| This PR | 7/7 |

The pre-existing `test_voucher_only_for_validated_picking_and_once` in `stock_batch_picking_ux` still passes, so the e1a2d10b behaviour is kept.
