### PR TITLE
[FIX] stock_batch_picking_ux: keep the partner filter out of _sanity_check

### DIFF
--- a/stock_batch_picking_ux/README.rst
+++ b/stock_batch_picking_ux/README.rst
@@ -18,6 +18,7 @@ This module add the following features:
 #. Add notes tab.
 #. Partner on the batch transfer:
 -  The ``partner_id`` on the batch is **computed** from the partners of its pickings: it is set when all pickings share the same partner and cleared when there is a mix. It remains **editable manually** (e.g. to pre-set a partner on an empty batch and constrain which pickings can be attached via the domain).
+-  When a partner is set, the **Transfers** field only offers that partner's eligible transfers. This is UI help only: it is a domain on the field (``partner_allowed_picking_ids``) and does **not** narrow the native ``allowed_picking_ids``, which is what Odoo's ``_sanity_check`` uses to decide whether a transfer is compatible with the batch. Narrowing that field made adding a transfer of another partner — or with no partner at all — fail with "check their states and operation types", and only on some paths.
 -  Locked once the batch is ``done`` or ``cancel``.
 -  Shown in the list view of batches.
 #. While processing the batch picking:

--- a/stock_batch_picking_ux/models/stock_batch_picking.py
+++ b/stock_batch_picking_ux/models/stock_batch_picking.py
@@ -36,6 +36,17 @@ class StockPickingBatch(models.Model):
         string="# Transferencias",
         compute="_compute_picking_count",
     )
+    # Ayuda de UI: los traslados elegibles acotados al cliente del lote. Es el
+    # dominio del campo Traslados en la vista. Va aparte de allowed_picking_ids
+    # a propósito: ese campo lo usa el _sanity_check nativo, así que filtrarlo
+    # por cliente hacía estallar el alta de un traslado de otro cliente (o sin
+    # cliente) con un mensaje que manda a revisar estado y tipo de operación,
+    # que estaban perfectos — y solo por algunos caminos, según si el compute de
+    # partner_id llegaba a recalcular antes (tarea 73086).
+    partner_allowed_picking_ids = fields.One2many(
+        "stock.picking",
+        compute="_compute_partner_allowed_picking_ids",
+    )
     notes = fields.Text(help="free form remarks")
 
     # Stub to prevent AttributeError when l10n_pe_edi_stock is installed.
@@ -71,11 +82,13 @@ class StockPickingBatch(models.Model):
                 # lote sin traslados: no pisar el cliente cargado a mano
                 batch.partner_id = batch.partner_id
 
-    @api.depends("partner_id")
-    def _compute_allowed_picking_ids(self):
-        super()._compute_allowed_picking_ids()
-        for rec in self.filtered("partner_id"):
-            rec.allowed_picking_ids = rec.allowed_picking_ids.filtered(lambda p: p.partner_id == rec.partner_id)
+    @api.depends("partner_id", "allowed_picking_ids")
+    def _compute_partner_allowed_picking_ids(self):
+        for rec in self:
+            pickings = rec.allowed_picking_ids
+            if rec.partner_id:
+                pickings = pickings.filtered(lambda p: p.partner_id == rec.partner_id)
+            rec.partner_allowed_picking_ids = pickings
 
     def write(self, vals):
         # Intercept DELETE commands on picking_ids to prevent physical deletion —

--- a/stock_batch_picking_ux/views/stock_batch_picking_views.xml
+++ b/stock_batch_picking_ux/views/stock_batch_picking_views.xml
@@ -40,12 +40,21 @@
             <!-- No permitir cargar traslados hasta elegir el tipo de operación:
                  sin tipo, allowed_picking_ids nativo no filtra por picking_type y
                  ofrece todos los traslados de la compañía (recepciones, entregas,
-                 internos mezclados). Forzamos el orden tipo → traslados. -->
+                 internos mezclados). Forzamos el orden tipo → traslados.
+
+                 El acotado por cliente va acá, como dominio del campo, y no
+                 dentro de allowed_picking_ids: ese lo usa el _sanity_check
+                 nativo (ver comentario en el modelo). -->
+            <field name="allowed_picking_ids" position="after">
+                <field name="partner_allowed_picking_ids" invisible="1"/>
+            </field>
             <xpath expr="//field[@name='picking_ids'][@widget='many2many']" position="attributes">
                 <attribute name="readonly">not picking_type_id or state not in ['draft', 'in_progress']</attribute>
+                <attribute name="domain">[('id', 'in', partner_allowed_picking_ids)]</attribute>
             </xpath>
             <xpath expr="//field[@name='picking_ids'][@widget='stock_picking_many2many']" position="attributes">
                 <attribute name="readonly">not picking_type_id or state not in ['draft', 'in_progress']</attribute>
+                <attribute name="domain">[('id', 'in', partner_allowed_picking_ids)]</attribute>
             </xpath>
 
             <button name="action_cancel" position="attributes">


### PR DESCRIPTION
Pending point of #990: the batch's partner filter was living inside `allowed_picking_ids`, which is the field the native `_sanity_check` compares the batch transfers against. Narrowing it turned perfectly valid transfers into "incompatible" ones and aborted the operation with a message that sends you to check states and operation types, which were fine.

### What actually breaks

- **A transfer with no partner** (an ordinary delivery loaded without a contact) added to a batch that has one. `_compute_partner_id` ignores partner-less pickings when deriving, so the batch keeps its partner and the filter leaves that transfer out of the allowed set → `UserError`, the transfer can't be added.
- **Saving the form** with the customer and the transfers in the same write: `env.protecting` keeps the stored compute of `partner_id` from recomputing, so the batch ends up with customer A plus a transfer of B — and *any* later write carrying `picking_type_id` blows up on the sanity check.

It also only fired on some paths, which made it look random: `_sanity_check` is not a constraint. It runs from `picking.write({'batch_id': ...})` (the "Add to batch" action) and from `batch.write()` when `picking_type_id` travels. Whether it raised depended on the stored compute of `partner_id` having recomputed to `False` first — on the paths where it does, the customer is silently cleared instead.

### Change

- New `partner_allowed_picking_ids` compute (`allowed_picking_ids` narrowed by `partner_id`), used as the `domain` of the Transfers field in the form view.
- Drop the `_compute_allowed_picking_ids` override, so the native field — and the sanity check that reads it — is untouched.

The UI help is unchanged: with a customer set, the Transfers field still only offers that customer's eligible transfers. What changes is that the narrowing no longer decides compatibility, so the behaviour stops depending on the path taken.

### Test plan

No automated tests in this PR. Checked on a v19 database with the module installed, against the two paths above:

- a transfer with no partner joins a batch that has one, without raising;
- an incoherent batch (manual customer + transfers of another) no longer blocks a later write that triggers the sanity check;
- the UI narrowing still holds — with a customer set the Transfers field only offers that customer's transfers — while `allowed_picking_ids` still returns the other customer's transfer;
- with no customer on the batch, the UI domain does not narrow anything.

The module's existing suite stays green.

Task: https://www.adhoc.inc/odoo/project.task/73086
