### PR TITLE
[IMP] stock_currency_valuation_recompute: correct a manual revaluation by hand

### DIFF
--- a/stock_currency_valuation_recompute/README.rst
+++ b/stock_currency_valuation_recompute/README.rst
@@ -87,6 +87,34 @@ them; once the cause is sorted out, compute their lines again — which clears t
 and revaluate. Only a record with computed lines can be revaluated, so a failure of the
 compute step can never be applied.
 
+Correcting a manual revaluation
+-------------------------------
+
+Only the layers created after the last manual valuation are adjusted, so the tool never
+rewrites a manual revaluation on its own. To correct one whose value in the secondary
+currency was loaded wrong, drive it in two passes:
+
+#. Compute the lines. The manual revaluation appears as a line of type *before adjustment*,
+   unticked
+#. Tick it, and set the value in the secondary currency to what it should be. A revaluation
+   has no quantity, so the unit cost does not matter, and the company-currency side is
+   already filled in with the recorded value — leave it as it is to keep the amount in
+   company currency unchanged
+#. Optionally, untick the remaining lines. They were computed from the wrong revaluation,
+   so leaving them ticked writes them — and reposts their journal entries — with figures the
+   second pass corrects anyway. The end state is the same either way; unticking only avoids
+   the round trip
+#. Press "Revaluate". The layer and its journal entry are corrected, and the entry is
+   posted again with the same amount in company currency
+#. Create a **new** recompute for the product and compute its lines. The corrected
+   revaluation is now respected as the cut, and every layer after it — and the product cost
+   — is recalculated from it
+#. Review and press "Revaluate"
+
+The second pass is not optional: the product cost written by the first one still comes from
+the figures computed before the correction. Only after the second pass does the cost match
+the sum of the layers again.
+
 Known issues / Roadmap
 ======================
 

--- a/stock_currency_valuation_recompute/tests/test_layer_recompute.py
+++ b/stock_currency_valuation_recompute/tests/test_layer_recompute.py
@@ -146,6 +146,50 @@ class TestLayerRecompute(TransactionCase):
 
         self.assertFalse(recompute.revaluation_error, "Un registro sano no puede mostrar un motivo de falla")
 
+    def test_a_manual_revaluation_can_be_corrected_in_two_passes(self):
+        """Corregir a mano una revaluacion, y que el recompute siguiente la respete.
+
+        Es el recorrido que le queda al operador para arreglar una revaluacion cuyo valor
+        en la moneda secundaria se cargo mal: el recalculo no la toca por diseno, asi que
+        la correccion se tilda a mano y el segundo recompute reacomoda todo lo posterior.
+        """
+        Recompute = self.env["stock.valuation.layer.recompute"]
+        product, adjustment = self._make_product_with_drift("Producto A")
+
+        # pasada 1: tildo la linea del ajuste, la corrijo, y destildo las demas
+        first = Recompute.create({"company_id": self.env.company.id, "product_id": product.id})
+        first.action_compute_lines()
+        adjustment_line = first.line_ids.filtered(lambda line: line.layer_id == adjustment)
+        self.assertFalse(adjustment_line.need_changes, "El ajuste manual sale sin marcar")
+        value_in_company_currency = adjustment.value
+        adjustment_line.need_changes = True
+        adjustment_line.new_value_in_currency = 30.0
+        (first.line_ids - adjustment_line).need_changes = False
+
+        first.action_manual_slv_revaluation()
+
+        self.assertEqual(adjustment.value_in_currency, 30.0, "La correccion tiene que aplicarse")
+        self.assertEqual(adjustment.value, value_in_company_currency, "El importe en pesos no cambia")
+
+        # pasada 2: recompute nuevo, sin tocar nada a mano
+        second = Recompute.create({"company_id": self.env.company.id, "product_id": product.id})
+        second.action_compute_lines()
+        second_line = second.line_ids.filtered(lambda line: line.layer_id == adjustment)
+        self.assertEqual(second_line.new_value_in_currency, 30.0, "Tiene que respetar la correccion")
+        self.assertFalse(second_line.need_changes, "Y no querer volver a escribirla")
+
+        second.action_manual_slv_revaluation()
+
+        layers = self.env["stock.valuation.layer"].search(
+            [("product_id", "=", product.id), ("company_id", "=", self.env.company.id)]
+        )
+        self.assertAlmostEqual(
+            product.standard_price_in_currency * sum(layers.mapped("quantity")),
+            sum(layers.mapped("value_in_currency")),
+            places=2,
+            msg="Despues de la segunda pasada el costo tiene que cerrar contra la suma de capas",
+        )
+
     def test_queue_revaluation_skips_records_already_applied(self):
         """Encolar en masa no vuelve a mandar un registro ya aplicado."""
         recompute = self.env["stock.valuation.layer.recompute"].create({"company_id": self.env.company.id})

--- a/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
+++ b/stock_currency_valuation_recompute/views/stock_valuation_layer_recompute.xml
@@ -34,7 +34,10 @@
                         <field name="last_manual_svl_id" readonly="1"/>
                     </group>
                     <field name="line_ids" readonly="state in ['done', 'cancel']">
-                        <list>
+                        <!-- editable en la fila: la correccion se tilda y se tipea ahi mismo,
+                             sin abrir el dialogo. `create` en cero porque las lineas salen de
+                             los layers del producto, no se cargan a mano. -->
+                        <list editable="bottom" create="0">
                             <field name="currency_id" column_invisible="True"/>
                             <field name="company_currency_id" column_invisible="True"/>
                             <field name="layer_date" readonly="1" optional="hide"/>
@@ -52,7 +55,9 @@
                             <field name="new_value_in_currency"/>
                             <field name="standard_price" currency_field="company_currency_id"/>
                             <field name="standard_price_in_currency"/>
-                            <field name="need_changes" readonly="1"/>
+                            <!-- editable a proposito: permite corregir a mano una
+                                 revaluacion que el recalculo respeta por diseno -->
+                            <field name="need_changes"/>
                         </list>
                     </field>
                 </sheet>


### PR DESCRIPTION
Only the layers created after the last manual valuation are adjusted, so the tool never rewrites a manual revaluation on its own. That cut is deliberate — it is what keeps an adjustment from being counted twice.

The consequence is a gap: a revaluation whose value in the secondary currency was loaded wrong has no route back through the tool. Computing its lines shows it unticked, editing the proposed values does nothing, and the operator has to ask for the layer to be corrected in the database.

## What changes

`need_changes` becomes editable on the lines, which is that route. One attribute.

Ticking the revaluation's line and setting its value in the secondary currency applies the correction to the layer and to its journal entry, and the entry is posted again with the same amount in company currency — the company-currency side of the line is already filled in with the recorded value, so leaving it alone keeps that amount unchanged. A revaluation has no quantity, so its unit cost does not enter into it.

That is only the first of two passes, and the README spells out both, including why the second is not optional: the product cost written by the first still comes from the figures computed before the correction. A second recompute takes the corrected revaluation as its cut and recalculates every layer after it along with the cost — the tool doing exactly what it was built for.

## Verified on a database shaped like the affected one

Company in ARS, valuation in USD, automated valuation, and a manual revaluation carrying its posted journal entry:

```
Pass 1 — tick the revaluation's line, set USD 30
  layer   → ARS 5000 unchanged | USD 50 → 30
  entry   → amount_currency 30 / −30, still posted and balanced

Pass 2 — a new recompute, nothing edited by hand
  layer 9   before adjustment   unticked   USD  30.00   ← correction respected
  layer 10  inventory           ticked     USD −26.00   ← was −30.00
  product cost → USD 13.00

Result: cost 13 × 8 units in stock = USD 104 = sum of the layers. No unposted entries.
```

Unticking the remaining lines in pass 1 turns out to be optional, so the README presents it that way. Both paths were run to the end and land on the same figures — cost USD 13, layers summing to USD 104, no unposted entries. The only difference is intermediate: left ticked, the later layer is written to a value derived from the wrong revaluation (−30) and its entry is redrafted and reposted a second time in pass 2; unticked, it simply keeps its recorded value until pass 2 corrects it.

Also verified, and the reason the editable tick is the right lever rather than editing the proposed values alone: a correction typed onto a line of an ordinary layer (one with a stock move) does get applied, but the next compute re-derives that layer and proposes overwriting it. Only a manual revaluation is respected across passes, because only it becomes the cut.

## Test plan

`stock_currency_valuation_recompute` tests, 11 passed. The new one, `test_a_manual_revaluation_can_be_corrected_in_two_passes`, walks the whole flow: the revaluation's line comes out unticked, ticking it and setting the secondary-currency value applies it while the company-currency amount stays put, a second recompute respects the correction and does not want to rewrite it, and after the second pass the product cost multiplied by the quantity in stock equals the sum of the layers again.