### PR TITLE
[FIX] stock_ux: net quantity column visibility and location-select crash

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "19.0.1.16.0",
+    "version": "19.0.1.17.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/models/stock_move_line.py
+++ b/stock_ux/models/stock_move_line.py
@@ -25,6 +25,10 @@ class StockMoveLine(models.Model):
     product_uom_qty_location = fields.Float(
         compute="_compute_product_uom_qty_location",
         string="Net Quantity",
+        help="Quantity of this line relative to the location searched with the 'Net Quantity "
+        "Location' filter: negative when the line leaves that location, positive when it enters, "
+        "and 0 when it does not apply. Without that filter it is always 0 by design; the useful "
+        "value is the column total at the bottom.",
     )
     origin_description = fields.Char(
         related="move_id.origin_description",
@@ -41,7 +45,10 @@ class StockMoveLine(models.Model):
         # _get_domain_locations on stock/product.py
         location_name = location[0]
         if isinstance(location[0], int):
-            location_name = self.env["stock.location"].browse(location[0]).reference
+            # When the location is picked from the search dropdown, 'location' carries the record
+            # id (int) instead of the typed text. stock.location has no 'reference' field, so we
+            # resolve it through 'complete_name' (same field the ilike below matches against).
+            location_name = self.env["stock.location"].browse(location[0]).complete_name
         locations = self.env["stock.location"].search([("complete_name", "ilike", location_name)])
         for rec in self:
             product_uom_qty_location = rec.quantity

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,1 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
 from . import test_mto_warehouse_propagation
+from . import test_product_uom_qty_location

--- a/stock_ux/tests/test_product_uom_qty_location.py
+++ b/stock_ux/tests/test_product_uom_qty_location.py
@@ -1,0 +1,95 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from lxml import etree
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestProductUomQtyLocation(TransactionCase):
+    """Comportamiento de stock.move.line.product_uom_qty_location ("Net Quantity").
+
+    El compute es relativo a la ubicacion que viaja en el contexto ('location'), que el
+    facet de busqueda "Net Quantity Location" inyecta como LISTA (texto tipeado -> str,
+    seleccion del desplegable -> id int). Verificamos los tres caminos y el signo.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.stock_loc = cls.warehouse.lot_stock_id
+        cls.customer_loc = cls.env.ref("stock.stock_location_customers")
+        cls.supplier_loc = cls.env.ref("stock.stock_location_suppliers")
+        # sub-ubicacion dentro de Stock, para el caso "origen y destino en la misma ubicacion"
+        cls.shelf_loc = cls.env["stock.location"].create(
+            {"name": "Shelf Test", "location_id": cls.stock_loc.id, "usage": "internal"}
+        )
+        cls.product = cls.env["product.product"].create({"name": "Net Qty Test Product", "is_storable": True})
+
+    def _make_move_line(self, src, dest, qty=5.0):
+        """Crea una stock.move.line concreta (via su move) entre src y dest."""
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "product_uom_qty": qty,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+            }
+        )
+        return self.env["stock.move.line"].create(
+            {
+                "move_id": move.id,
+                "product_id": self.product.id,
+                "quantity": qty,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+            }
+        )
+
+    def test_00_sin_ubicacion_da_cero(self):
+        """Sin 'location' en el contexto, el campo es 0 por diseno."""
+        ml = self._make_move_line(self.stock_loc, self.customer_loc)
+        self.assertEqual(ml.product_uom_qty_location, 0.0)
+
+    def test_01_salida_por_texto_da_negativo(self):
+        """Salida de la ubicacion buscada (facet por TEXTO) -> negativo."""
+        ml = self._make_move_line(self.stock_loc, self.customer_loc, qty=5.0)
+        ml = ml.with_context(location=[self.stock_loc.complete_name])
+        self.assertEqual(ml.product_uom_qty_location, -5.0)
+
+    def test_02_entrada_por_texto_da_positivo(self):
+        """Entrada a la ubicacion buscada (origen externo) -> positivo."""
+        ml = self._make_move_line(self.supplier_loc, self.stock_loc, qty=5.0)
+        ml = ml.with_context(location=[self.stock_loc.complete_name])
+        self.assertEqual(ml.product_uom_qty_location, 5.0)
+
+    def test_03_origen_y_destino_en_ubicacion_da_cero(self):
+        """Movimiento interno dentro del arbol de la ubicacion buscada -> 0."""
+        ml = self._make_move_line(self.stock_loc, self.shelf_loc, qty=5.0)
+        ml = ml.with_context(location=[self.stock_loc.complete_name])
+        self.assertEqual(ml.product_uom_qty_location, 0.0)
+
+    def test_04_seleccion_por_id_no_crashea_y_da_negativo(self):
+        """Facet por SELECCION del desplegable: 'location' llega como [id] (int).
+
+        Antes del fix esto explotaba con AttributeError porque stock.location no tiene
+        campo 'reference'. Ahora resuelve por complete_name y da el mismo resultado que
+        el path de texto.
+        """
+        ml = self._make_move_line(self.stock_loc, self.customer_loc, qty=5.0)
+        ml = ml.with_context(location=[self.stock_loc.id])
+        self.assertEqual(ml.product_uom_qty_location, -5.0)
+
+    def test_05_columna_oculta_sin_ubicacion_en_la_vista(self):
+        """La vista de lista debe ocultar la columna cuando no hay 'location' (column_invisible)."""
+        view = self.env.ref("stock_ux.view_move_line_tree2")
+        arch = etree.fromstring(view.arch)
+        nodes = arch.xpath("//field[@name='product_uom_qty_location']")
+        self.assertTrue(nodes, "La columna product_uom_qty_location no esta en la vista")
+        self.assertEqual(
+            nodes[0].get("column_invisible"),
+            "not context.get('location', False)",
+            "La columna deberia ocultarse por contexto de ubicacion (toggle recuperado)",
+        )

--- a/stock_ux/views/stock_move_line_views.xml
+++ b/stock_ux/views/stock_move_line_views.xml
@@ -43,9 +43,12 @@
         <field name="inherit_id" ref="stock.view_move_line_tree"/>
         <field name="arch" type="xml">
             <field name="location_dest_id" position="after">
-                <field name="product_uom_qty_location" sum="Total"/>
-                <!-- on enterprise view is not refres -->
-                <!-- <field name="product_uom_qty_location" sum="Total" invisible="not context.get('location', False)"/> -->
+                <!-- La columna solo tiene sentido cuando se filtra por "Cantidad neta en
+                     ubicacion" (ese facet inyecta 'location' en el contexto). En el cliente web
+                     Owl la visibilidad de columna por contexto de facet ya refresca, por eso la
+                     ocultamos cuando no hay ubicacion (antes daba 0,00 y confundia). -->
+                <field name="product_uom_qty_location" sum="Total"
+                       column_invisible="not context.get('location', False)"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## What

The **"Net Quantity"** column in the product move history (`stock.move.line.product_uom_qty_location`, module `stock_ux`) was always visible and showed `0.00` on every row unless the user filtered by the **"Net Quantity Location"** search facet. Because the value only makes sense relative to a location injected in the context, without that facet the column reads as a broken field and generates recurring user questions.

## Changes

- **View (`stock_move_line_views.xml`):** restore the column toggle with `column_invisible="not context.get('location', False)"`. The conditional visibility existed originally but was commented out years ago with a note that it did not refresh on the enterprise view. On the current web client the search-facet context does reach the list column evaluation, so the column is now hidden when there is no location in the context.
- **Model (`stock_move_line.py`):** fix an `AttributeError` raised when the location is **selected from the search dropdown** (the context carries the record id, an `int`) instead of typed as text. The compute resolved the id through a non-existent `reference` field on `stock.location`; it now uses `complete_name`, the same field the `ilike` search below matches against. Add a `help` text on the field.
- **Tests:** integration tests covering the compute (no location, outgoing, incoming, internal move, and id-based context) and the `column_invisible` toggle in the view.

## Test plan

- `stock_ux` test suite is green (`test_product_uom_qty_location` + existing `test_mto_warehouse_propagation`).
- The id-based test reproduces the crash before the fix (`AttributeError: 'stock.location' object has no attribute 'reference'`) and passes after it.
- Manual check on runbot: open a product's *Detailed move history*; the "Net Quantity" column is hidden by default and appears (with correct signed values) once you filter by **"Net Quantity Location"**, both by typing text and by picking a location from the dropdown.

Task: https://www.adhoc.inc/odoo/project.task/73348
