### PR TITLE
[FIX] stock_currency_valuation_recompute: do not propose what the lock forbids

### DIFF
--- a/stock_currency_valuation_recompute/README.rst
+++ b/stock_currency_valuation_recompute/README.rst
@@ -87,6 +87,21 @@ them; once the cause is sorted out, compute their lines again — which clears t
 and revaluate. Only a record with computed lines can be revaluated, so a failure of the
 compute step can never be applied.
 
+Closed periods
+--------------
+
+A layer whose journal entry falls on or before the company's fiscal lock date is never
+proposed for adjustment. It is listed with the type *locked period* so it can be seen, and
+left with its recorded values, exactly as the layers before a manual valuation are.
+
+This is not only about respecting the close. Revaluating is all or nothing per record, so a
+single line in a closed period makes the whole product's correction fail — including the
+part that could have been applied. Reopening the period is an accounting decision; once the
+lock moves, the tool follows it with no configuration.
+
+A run can be narrowed further with the ``recompute_from_date`` context key, which moves the
+floor forward — never back, since proposing below the lock is what this avoids.
+
 Known issues / Roadmap
 ======================
 

--- a/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
+++ b/stock_currency_valuation_recompute/models/stock_valuation_layer_recompute.py
@@ -155,6 +155,34 @@ class StockValuationLayerRecompute(models.Model):
         if self.product_id.with_company(self.company_id).lot_valuated:
             raise UserError("El producto tiene valuación por lote (lot_valuated) y este recálculo no la contempla.")
 
+    def _layer_accounting_date(self, layer):
+        """La fecha con la que se juzga si una capa cae en periodo cerrado.
+
+        Es la del asiento, que es la que mira el bloqueo fiscal; la de la capa queda de
+        respaldo para las que no tienen asiento.
+        """
+        return layer.account_move_id.date or layer.create_date.date()
+
+    def _get_recompute_floor_date(self):
+        """Fecha desde la cual tiene sentido corregir.
+
+        Lo anterior al bloqueo fiscal no se puede escribir, y proponerlo igual no es
+        inocuo: revaluar es todo o nada por registro, asi que una sola linea en periodo
+        cerrado hace fallar la correccion entera del producto, incluida la parte que si
+        se podia aplicar.
+
+        La clave de contexto `recompute_from_date` corre el piso hacia adelante, para
+        acotar una corrida a un periodo mas chico que el que el bloqueo ya permite. Nunca
+        hacia atras: proponer por debajo del bloqueo es exactamente lo que se esta
+        evitando. Sin bloqueo configurado el piso es `date.min` y esto no cambia nada.
+        """
+        self.ensure_one()
+        # Sin diario: el de valuacion no es de venta ni de compra, asi que el piso sale
+        # del cierre de ejercicio y del bloqueo duro.
+        floor = self.company_id.sudo()._get_user_fiscal_lock_date(self.env["account.journal"])
+        forced = self.env.context.get("recompute_from_date")
+        return max(floor, fields.Date.to_date(forced)) if forced else floor
+
     def action_compute_lines(self):
         self.ensure_one()
         self._check_supported_product()
@@ -165,6 +193,7 @@ class StockValuationLayerRecompute(models.Model):
         self.last_manual_svl_id = last_manual_svl_id
 
         lines_to_zero = self.env.context.get("lines_to_zero", {})
+        floor_date = self._get_recompute_floor_date()
 
         leaf = [("company_id", "=", self.company_id.id), ("product_id", "=", self.product_id.id)]
         svl_ids = self.env["stock.valuation.layer"].search(leaf, order="create_date asc")
@@ -198,7 +227,8 @@ class StockValuationLayerRecompute(models.Model):
             }
             quantity_at_time = quantity_at_time + svl_id.quantity
             after_last_manual = not last_manual_svl_id or svl_id.id > last_manual_svl_id.id
-            if not after_last_manual:
+            in_locked_period = self._layer_accounting_date(svl_id) <= floor_date
+            if not after_last_manual or in_locked_period:
                 # El ajuste manual y todo lo anterior se respeta, asi que estos layers no
                 # se van a escribir. El promedio ponderado tiene que avanzar con el valor
                 # REGISTRADO, que es el que va a quedar, y no con el recalculado: si no,
@@ -212,7 +242,7 @@ class StockValuationLayerRecompute(models.Model):
                 standard_price_in_currency = self._get_standard_price(
                     new_value_in_currency, standard_price_in_currency, quantity_at_time, svl_id.quantity
                 )
-                svl_type = "before adjustment"
+                svl_type = "locked period" if in_locked_period else "before adjustment"
 
             elif svl_id.id in lines_to_zero:
                 new_unit_cost = 0
@@ -388,7 +418,7 @@ class StockValuationLayerRecompute(models.Model):
             # usuario se respeta tal cual, y con el todo lo anterior. Sin este corte, un
             # ajuste que compensaba un layer mal valuado se termina contando dos veces:
             # una en el layer recalculado y otra en el ajuste que sigue ahi.
-            need_change_5 = after_last_manual
+            need_change_5 = after_last_manual and not in_locked_period
             need_change_6 = svl_id.id in lines_to_zero
             vals["need_changes"] = bool(
                 (need_change_1 or need_change_2 or need_change_3 or need_change_4 or need_change_6) and need_change_5

--- a/stock_currency_valuation_recompute/tests/test_layer_recompute.py
+++ b/stock_currency_valuation_recompute/tests/test_layer_recompute.py
@@ -1,3 +1,4 @@
+from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import mute_logger
@@ -153,6 +154,72 @@ class TestLayerRecompute(TransactionCase):
 
         with self.assertRaises(UserError):
             recompute.action_queue_revaluation()
+
+    def test_layers_in_a_locked_period_are_not_proposed_for_change(self):
+        """Lo que el bloqueo fiscal no deja escribir tampoco se propone.
+
+        Revaluar es todo o nada por registro, asi que una sola linea en periodo cerrado
+        hace fallar la correccion entera del producto, incluida la parte aplicable.
+        """
+        product, _adjustment = self._make_product_with_drift("Producto A")
+        self._close_period_up_to(fields.Date.today())
+
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": product.id}
+        )
+        recompute.action_compute_lines()
+
+        self.assertTrue(recompute.line_ids, "Las lineas se arman igual, para poder mirarlas")
+        self.assertFalse(
+            recompute.line_ids.filtered("need_changes"),
+            "Ninguna capa del periodo cerrado se puede proponer para ajuste",
+        )
+        self.assertEqual(set(recompute.line_ids.mapped("svl_type")), {"locked period"})
+
+    def test_the_floor_can_be_moved_forward_from_the_context(self):
+        """El script puede acotar una corrida a un periodo mas chico que el bloqueo."""
+        product, _adjustment = self._make_product_with_drift("Producto A")
+        Recompute = self.env["stock.valuation.layer.recompute"]
+
+        without_floor = Recompute.create({"company_id": self.env.company.id, "product_id": product.id})
+        without_floor.action_compute_lines()
+        self.assertTrue(without_floor.line_ids.filtered("need_changes"), "Sin piso hay ajustes")
+
+        with_floor = Recompute.create({"company_id": self.env.company.id, "product_id": product.id})
+        with_floor.with_context(recompute_from_date=fields.Date.today()).action_compute_lines()
+
+        self.assertFalse(
+            with_floor.line_ids.filtered("need_changes"),
+            "Con el piso en hoy, las capas de hoy quedan fuera del ajuste",
+        )
+
+    def test_the_floor_cannot_be_moved_back_before_the_lock(self):
+        """El contexto no puede aflojar el bloqueo: proponer bajo el es lo que se evita."""
+        product, _adjustment = self._make_product_with_drift("Producto A")
+        self._close_period_up_to(fields.Date.today())
+
+        recompute = self.env["stock.valuation.layer.recompute"].create(
+            {"company_id": self.env.company.id, "product_id": product.id}
+        )
+        recompute.with_context(recompute_from_date="2020-01-01").action_compute_lines()
+
+        self.assertFalse(
+            recompute.line_ids.filtered("need_changes"),
+            "El bloqueo manda por sobre el contexto",
+        )
+
+    def _close_period_up_to(self, lock_date):
+        """Cierra el ejercicio hasta esa fecha, escribiendo el campo directo.
+
+        No via `write`: el `_validate_locks` de Odoo rechaza cerrar un periodo que tenga
+        lineas de extracto sin conciliar, y la data demo de la base de test las tiene. Eso
+        es una precondicion del entorno, no lo que se esta probando, asi que se saltea.
+        """
+        self.env.cr.execute(
+            "UPDATE res_company SET fiscalyear_lock_date = %s WHERE id = %s",
+            (lock_date, self.env.company.id),
+        )
+        self.env.company.invalidate_recordset()
 
     def _make_computed_recompute(self, name):
         """Recompute ya calculado y con diferencias, o sea aplicable."""


### PR DESCRIPTION
The tool's only cut is the last manual valuation of each product, so it replays the whole history and proposes corrections on layers of any age. On a database whose fiscal year is closed up to a recent date, most of what it proposes cannot be written at all.

That is not a harmless surplus. **Revaluating is all or nothing per record**, so a single line in a closed period makes the correction of the whole product fail — including the part that could have been applied.

On the affected database, with the fiscal year closed through 30/06/2026:

| | records |
|---|---|
| pending | 928 |
| carrying at least one line in the closed period | 779 |
| **actually appliable** | **149** |

## What changes

A layer whose journal entry falls on or before the company's fiscal lock date is treated the same way as a layer before a manual valuation: kept with its recorded values, with the running average advancing on them, so the product cost still adds up against what is really in the books. That branch already existed and is what the manual-valuation cut uses — this only gives it a second reason to apply, so there is no new arithmetic.

It is listed as `locked period` rather than `before adjustment`, so the reason a line carries no proposal is on screen rather than something to work out.

## Where the date comes from

The company, never a constant. `_get_user_fiscal_lock_date` accounts for the hard lock and for per-user exceptions, and returns `date.min` where nothing is closed — so on a database with no lock the behaviour is exactly what it was. As the close advances the tool follows it with no configuration.

`recompute_from_date` in the context narrows a run further, for scripting a campaign against a smaller window than the close already allows. It moves the floor **forward only**: clamped with `max()` against the lock, because proposing below the lock is precisely what this fixes.

The date judged is the journal entry's, which is what the lock looks at, with the layer's own date as a fallback for layers that have no entry.

## Test plan

`stock_currency_valuation_recompute` tests, 13 passed. Three are new:

- `test_layers_in_a_locked_period_are_not_proposed_for_change` — with the fiscal year closed through today, a product that otherwise has corrections to make comes out with no ticked line and every line typed `locked period`.
- `test_the_floor_can_be_moved_forward_from_the_context` — the same product proposes changes with no floor, and none once `recompute_from_date` is set to today.
- `test_the_floor_cannot_be_moved_back_before_the_lock` — a context date well before the lock does not reopen it.

The ten pre-existing tests run on a database with no lock date, so they also cover that this is inert where nothing is closed.