### PR TITLE
[FIX] stock_batch_picking_ux: stamp the batch voucher on every validation path

### DIFF
--- a/stock_batch_picking_ux/models/stock_batch_picking.py
+++ b/stock_batch_picking_ux/models/stock_batch_picking.py
@@ -156,22 +156,10 @@ class StockPickingBatch(models.Model):
         ).mapped("name")
 
         for rec in self:
+            # la rama incoming la estampa stock.picking._action_done, que además alcanza
+            # la validación diferida por el wizard de orden parcial
             if rec.picking_type_code == "incoming" and rec.voucher_number:
-                for picking in rec.picking_ids:
-                    if picking.state != "done" or picking.voucher_ids:
-                        continue
-                    # agregamos esto para que no se asigne a los pickings
-                    # que no se van a recibir ya que todavia no se limpiaron
-                    # y ademas, por lo de arriba, no se fuerza la cantidad
-                    # si son todos cero, se terminan sacando
-                    if all(operation.quantity == 0 for operation in picking.move_line_ids):
-                        continue
-                    rec.env["stock.picking.voucher"].create(
-                        {
-                            "picking_id": picking.id,
-                            "name": rec.voucher_number,
-                        }
-                    )
+                continue
             elif not batch_voucher_installed:
                 for picking in rec.picking_ids:
                     if picking.state != "done" or picking.voucher_ids:

--- a/stock_batch_picking_ux/models/stock_picking.py
+++ b/stock_batch_picking_ux/models/stock_picking.py
@@ -56,3 +56,19 @@ class StockPicking(models.Model):
             return True
         else:
             return super(StockPicking, self)._action_generate_backorder_wizard(show_transfers=show_transfers)
+
+    def _action_done(self):
+        # el número del lote de recepción se estampa al llegar a done (lote, wizard de
+        # orden parcial o traslado solo) y se lee antes del super, que desasigna batch_id;
+        # la condición es la misma que el guard de stock_voucher deja pasar
+        numbers = {
+            picking.id: picking.batch_id.voucher_number
+            for picking in self
+            if picking.batch_id.picking_type_code == "incoming"
+        }
+        res = super()._action_done()
+        for picking in self.filtered(lambda p: p.state == "done" and not p.voucher_ids):
+            number = numbers.get(picking.id)
+            if number and any(operation.quantity for operation in picking.move_line_ids):
+                self.env["stock.picking.voucher"].create({"picking_id": picking.id, "name": number})
+        return res

--- a/stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py
+++ b/stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py
@@ -90,3 +90,31 @@ class TestBatchVoucherOnValidate(TransactionCase):
         batch.action_done()
         self.assertEqual(picking.state, "done")
         self.assertEqual(len(picking.voucher_ids), 1)
+
+    def test_incoming_batch_numbers_after_backorder_wizard(self):
+        """El wizard de orden parcial valida por fuera del lote: el número tiene que quedar igual."""
+        picking_type = self.env.ref("stock.picking_type_in")
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.src.id,
+                "move_ids": [
+                    (0, 0, {"name": self.product.name, "product_id": self.product.id, "product_uom_qty": 2.0})
+                ],
+            }
+        )
+        batch = self.env["stock.picking.batch"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "picking_ids": [(6, 0, picking.ids)],
+                "voucher_number": "0001-00000456",
+            }
+        )
+        batch.action_confirm()
+        picking.move_ids.quantity = 1.0
+        action = batch.action_done()
+        self.assertFalse(picking.voucher_ids)
+
+        self.env[action["res_model"]].with_context(**action["context"]).create({}).process()
+        self.assertEqual(picking.voucher_ids.mapped("name"), ["0001-00000456"])


### PR DESCRIPTION
## Problema

Una recepción validada desde un lote puede quedar en **Hecho sin ningún remito**: el lote lleva el número y el traslado no muestra ninguno. Además de la falta del dato, rompe la búsqueda por remito en el matching de facturas, que filtra por `voucher_ids`.

## Causa

Los tipos de recepción crean órdenes parciales en modo *ask*, y `stock_batch_picking_ux.action_confirm` pone en 0 las cantidades de las operaciones para que el operario cargue sólo lo recibido: la recepción parcial es el caso normal, no el borde.

En ese caso el `action_done()` del core termina en `pickings.button_validate()`, `_pre_action_done_hook()` devuelve el wizard de orden parcial y `action_done()` **retorna sin haber validado nada**. El bloque post-super que agregó `e1a2d10b`, condicionado a `state == 'done'`, nunca corre; el wizard valida los traslados después, por su cuenta, y nadie estampa el número.

## Cambio

- El número se estampa en `stock.picking._action_done()`, el único punto por el que un traslado llega a *Hecho*: lote de una, wizard de orden parcial, o traslado validado solo.
- Se lee **antes** del super, porque el core desasigna `batch_id` mientras crea la orden parcial (`stock_picking_batch/models/stock_picking.py`).
- Sigue condicionado a `state == 'done'` y a que no haya remito, así que los dos invariantes de `e1a2d10b` (no numerar lo que no se validó, no duplicar en reintentos) no cambian.
- La rama `incoming` del post-super de `action_done` queda como código muerto y se va: estampaba sobre la misma condición que ya chequea el guard de `stock_voucher` y que ahora lee este método. Queda un solo dueño; la rama de talonario no se toca (ni se re-indenta).

Sólo 18.0: la familia `stock_voucher` no está migrada a 19.0 (el `stock_batch_picking_ux` de 19.0 no depende de ella ni tiene numeración en `action_done`), así que no hay forward-port.

## Test plan

`stock_batch_picking_ux/tests/test_batch_voucher_on_validate.py::test_incoming_batch_numbers_after_backorder_wizard` recorre el camino real: lote de recepción con número, recepción parcial, `action_done()` devuelve el wizard, `process()`, y se verifica que el traslado queda *Hecho* con el número del lote y que la orden parcial nueva queda sin remito.

Verificado local sobre el tip de 18.0, con `stock_ux`, `stock_voucher`, `stock_voucher_ux` y `stock_batch_picking_ux`:

- `-u` de los cuatro módulos con `--test-enable`: `0 failed, 0 error(s) of 17 tests`, sin warnings en el log — incluidos los tests de `e1a2d10b`, el del guard en `stock_voucher` y los de `stock_voucher_ux`, que numera talonarios en el mismo `_action_done`;
- el test nuevo discrimina: revirtiendo sólo los dos archivos de modelo falla con `AssertionError: Lists differ: [] != ['0001-00000456']`;

Al mergear va `nobump`: sólo Python, sin vistas, data, campos ni migraciones.
