### PR TITLE
[FIX] stock_voucher_ux, stock_voucher_ux_iot: do not count header-only pages

### DIFF
--- a/stock_voucher_ux/controllers/main.py
+++ b/stock_voucher_ux/controllers/main.py
@@ -9,55 +9,6 @@ from PyPDF2 import PdfFileReader
 
 
 class ReportController(report.ReportController):
-    def _count_pages_with_products(self, pdf_reader, picking_id):
-        """
-        Cuenta las páginas que realmente contienen productos
-        analizando el contenido de texto de cada página.
-        Usa identificadores de producto (código interno, código de barras)
-        para la detección, de forma independiente del idioma.
-        """
-        picking = request.env["stock.picking"].browse(picking_id)
-        move_lines = picking.move_line_ids
-
-        # Si no hay move_lines, usar move_ids como fallback
-        if not move_lines:
-            move_lines = picking.move_ids
-
-        # Recopilar identificadores de producto
-        product_identifiers = set()
-        for line in move_lines:
-            product = getattr(line, "product_id", None)
-            if product:
-                if product.default_code:
-                    product_identifiers.add(product.default_code.lower().strip())
-                if product.barcode:
-                    product_identifiers.add(product.barcode.lower().strip())
-
-        pages_with_products = 0
-
-        for page_num in range(len(pdf_reader.pages)):
-            try:
-                page = pdf_reader.pages[page_num]
-                text = page.extract_text()
-                if not text:
-                    continue
-                text_lower = text.lower()
-                if product_identifiers and any(pid in text_lower for pid in product_identifiers):
-                    has_products = True
-                else:
-                    # Fallback: patrón numérico genérico (independiente del idioma)
-                    has_products = bool(re.search(r"\b\d+[.,]\d+\b", text_lower))
-
-                if has_products:
-                    pages_with_products += 1
-
-            except Exception:
-                # Si hay error extrayendo texto, asumimos que tiene productos
-                pages_with_products += 1
-
-        # Asegurar que al menos hay 1 página con productos
-        return max(1, pages_with_products)
-
     @route()
     def report_download(self, data, context=None, token=None, **kwargs):
         """This function is used by 'qwebactionmanager.js' in order to trigger
@@ -75,7 +26,8 @@ class ReportController(report.ReportController):
             context_dict = json.loads(urllib.parse.unquote(context_part))
             picking_id = context_dict.get("active_ids")
             assign = context_dict.get("assign")
-            book_id = request.env["stock.picking"].browse(picking_id).book_id
+            picking = request.env["stock.picking"].browse(picking_id)
+            book_id = picking.book_id
             if assign and book_id and picking_id:
                 # Copias del reporte que se imprime, resuelto por su report_name en la URL.
                 copies = request.env["ir.actions.report"]._get_voucher_copies_from_url(url)
@@ -83,22 +35,16 @@ class ReportController(report.ReportController):
                 try:
                     pdf_response = response.response[0]
                     reader = PdfFileReader(io.BytesIO(pdf_response))
-
-                    # Usar el nuevo método para contar páginas con productos
+                    number_pages = picking._count_pages_with_products(reader)
                     if copies:
-                        total_pages = int(len(reader.pages) / copies)
-                        number_pages = self._count_pages_with_products(reader, picking_id)
                         # Ajustar por número de copias
-                        number_pages = min(number_pages, total_pages)
-                    else:
-                        number_pages = self._count_pages_with_products(reader, picking_id)
+                        number_pages = min(number_pages, int(len(reader.pages) / copies))
                 except Exception:
                     # If not PDF or can't process (like .doc), assign only 1 voucher
                     number_pages = 1
 
                 # See if there are vouchers already assigned. If not, assign them
                 # based on the real page count, then re-render so the numbers show.
-                picking = request.env["stock.picking"].browse(picking_id)
                 if not picking.voucher_ids and book_id:
                     picking.assign_numbers(number_pages, book_id)
                     picking.env.flush_all()
@@ -137,7 +83,7 @@ class ReportController(report.ReportController):
                             else:
                                 total_pages = len(reader.pages)
 
-                            number_pages = self._count_pages_with_products(reader, picking_id)
+                            number_pages = picking._count_pages_with_products(reader)
                             number_pages = min(number_pages, total_pages)
                         except Exception:
                             number_pages = 1

--- a/stock_voucher_ux/models/stock_picking.py
+++ b/stock_voucher_ux/models/stock_picking.py
@@ -2,6 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import re
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -60,6 +62,42 @@ class StockPicking(models.Model):
                     last_number,
                 )
             )
+
+    def _count_pages_with_products(self, pdf_reader):
+        """Páginas del PDF con productos del traslado: las demás no consumen remito."""
+        self.ensure_one()
+        products = (self.move_line_ids or self.move_ids).product_id
+        identifiers = set()
+        for product in products:
+            if product.default_code:
+                identifiers.add(product.default_code.lower().strip())
+            if product.barcode:
+                identifiers.add(product.barcode.lower().strip())
+        texts = []
+        for page in pdf_reader.pages:
+            try:
+                texts.append((page.extract_text() or "").lower())
+            except Exception:  # si no se puede leer, asumimos que trae productos
+                texts.append(None)
+        # Descartamos hojas sólo si toda línea se reconoce por código y el reporte
+        # los imprime. Si no, contamos como hasta ahora: de más antes que de menos,
+        # porque una hoja impresa sin número es peor que un número consumido.
+        identifiable = products and all(product.default_code or product.barcode for product in products)
+        use_codes = identifiable and any(text and any(code in text for code in identifiers) for text in texts)
+        pages_with_products = 0
+        for text in texts:
+            if text is None:
+                pages_with_products += 1
+                continue
+            if not text:
+                continue
+            if use_codes:
+                has_products = any(code in text for code in identifiers)
+            else:
+                has_products = bool(re.search(r"\b\d+[.,]\d+\b", text))
+            if has_products:
+                pages_with_products += 1
+        return max(1, pages_with_products)
 
     def do_print_and_assign(self):
         if not self.book_id and self.picking_type_code != "incoming":

--- a/stock_voucher_ux/tests/__init__.py
+++ b/stock_voucher_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_remito_preimpreso
+from . import test_count_pages

--- a/stock_voucher_ux/tests/test_count_pages.py
+++ b/stock_voucher_ux/tests/test_count_pages.py
@@ -1,0 +1,83 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class _FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class _FakeReader:
+    """Reemplazo duck-typed de ``PyPDF2.PdfFileReader`` para no renderizar un PDF."""
+
+    def __init__(self, texts):
+        self.pages = [_FakePage(text) for text in texts]
+
+
+class TestVoucherPageCount(TransactionCase):
+    """Sólo las páginas con productos consumen un número de remito."""
+
+    def _picking(self, *default_codes):
+        products = self.env["product.product"].create(
+            [
+                {"name": "Producto remito test %s" % index, "type": "consu", "default_code": code}
+                for index, code in enumerate(default_codes)
+            ]
+        )
+        location = self.env.ref("stock.stock_location_stock")
+        location_dest = self.env.ref("stock.stock_location_customers")
+        return self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "location_id": location.id,
+                "location_dest_id": location_dest.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom_qty": 1.0,
+                            "product_uom": product.uom_id.id,
+                            "location_id": location.id,
+                            "location_dest_id": location_dest.id,
+                        },
+                    )
+                    for product in products
+                ],
+            }
+        )
+
+    def test_page_without_products_does_not_consume_a_voucher(self):
+        # Segunda hoja: sólo el encabezado repetido, sin líneas, con un decimal
+        # en el domicilio ("Km 1,4") — el caso del ticket 126294.
+        reader = _FakeReader(
+            [
+                "1,00 UNIDAD TESTPROD [TESTPROD] Producto remito test",
+                "Cliente SRL - Ruta Provincial 4 Km 1,4 - Ciudad",
+            ]
+        )
+        self.assertEqual(
+            self._picking("TESTPROD")._count_pages_with_products(reader),
+            1,
+            "Una hoja que sólo repite el encabezado no lleva productos: no debe consumir remito.",
+        )
+        # Sin código que reconocer se sigue adivinando por el decimal.
+        self.assertEqual(self._picking(False)._count_pages_with_products(reader), 2)
+        # Y si el reporte no imprime el código, las hojas con líneas siguen contando.
+        sin_codigo = _FakeReader(["Producto remito test 1,00 UNIDAD", "Producto remito test 2,00 UNIDAD"])
+        self.assertEqual(
+            self._picking("TESTPROD")._count_pages_with_products(sin_codigo),
+            2,
+            "Si el código no aparece en ninguna hoja, no se puede usar para descartar hojas.",
+        )
+        # Y si alguna línea no tiene código, tampoco: una hoja con sólo esas líneas
+        # se descartaría y saldría impresa sin número.
+        self.assertEqual(self._picking("TESTPROD", False)._count_pages_with_products(reader), 2)

--- a/stock_voucher_ux_iot/models/ir_actions_report.py
+++ b/stock_voucher_ux_iot/models/ir_actions_report.py
@@ -4,7 +4,6 @@
 ##############################################################################
 import io
 import logging
-import re
 
 from odoo import models
 
@@ -71,7 +70,7 @@ class IrActionsReport(models.Model):
         try:
             content = self._render(self.report_name, picking.ids, data=data)[0]
             reader = PdfFileReader(io.BytesIO(content))
-            pages_with_products = self._count_pages_with_products(reader, picking)
+            pages_with_products = picking._count_pages_with_products(reader)
             copies = self.copies or 0
             if copies:
                 total_pages = int(len(reader.pages) / copies)
@@ -79,40 +78,3 @@ class IrActionsReport(models.Model):
             return max(1, pages_with_products)
         except Exception:  # noqa: BLE001 - any render/parse issue -> single voucher
             return 1
-
-    def _count_pages_with_products(self, pdf_reader, picking):
-        """Count the pages that actually contain products by matching product
-        identifiers (internal reference / barcode) in the page text, in a
-        language independent way. Mirrors the logic used by the download
-        controller in ``stock_voucher_ux``."""
-        move_lines = picking.move_line_ids or picking.move_ids
-
-        product_identifiers = set()
-        for line in move_lines:
-            product = line.product_id
-            if not product:
-                continue
-            if product.default_code:
-                product_identifiers.add(product.default_code.lower().strip())
-            if product.barcode:
-                product_identifiers.add(product.barcode.lower().strip())
-
-        pages_with_products = 0
-        for page_num in range(len(pdf_reader.pages)):
-            try:
-                text = pdf_reader.pages[page_num].extract_text()
-                if not text:
-                    continue
-                text_lower = text.lower()
-                if product_identifiers and any(pid in text_lower for pid in product_identifiers):
-                    has_products = True
-                else:
-                    # Fallback: generic numeric pattern (language independent).
-                    has_products = bool(re.search(r"\b\d+[.,]\d+\b", text_lower))
-                if has_products:
-                    pages_with_products += 1
-            except Exception:  # noqa: BLE001 - if text can't be extracted assume it has products
-                pages_with_products += 1
-
-        # There is always at least one page with products.
-        return max(1, pages_with_products)

--- a/stock_voucher_ux_iot/tests/test_iot_voucher.py
+++ b/stock_voucher_ux_iot/tests/test_iot_voucher.py
@@ -7,22 +7,6 @@ from unittest.mock import patch
 from odoo.tests.common import TransactionCase, tagged
 
 
-class _FakePage:
-    def __init__(self, text):
-        self._text = text
-
-    def extract_text(self):
-        return self._text
-
-
-class _FakeReader:
-    """Duck-typed stand-in for ``PyPDF2.PdfFileReader`` so the page-counting
-    logic can be tested without rendering a real (LibreOffice) aeroo PDF."""
-
-    def __init__(self, texts):
-        self.pages = [_FakePage(t) for t in texts]
-
-
 @tagged("post_install", "-at_install")
 class TestStockVoucherUxIot(TransactionCase):
     @classmethod
@@ -158,17 +142,3 @@ class TestStockVoucherUxIot(TransactionCase):
         ):
             other_report.render_and_send([], picking.ids)
         self.assertFalse(picking.voucher_ids, "Only the remito report must assign voucher numbers")
-
-    def test_count_pages_with_products(self):
-        """Pages are counted as containing products when the product code (or a
-        generic decimal, as fallback) shows up in the page text."""
-        picking = self._new_picking()
-        reader = _FakeReader(
-            [
-                "Cliente XYZ\nProducto TESTPROD1 x 1",  # product code -> counts
-                "Página de continuación sin líneas",  # nothing -> not counted
-                "12,50 total",  # decimal fallback -> counts
-                "",  # empty -> not counted
-            ]
-        )
-        self.assertEqual(self.report._count_pages_with_products(reader, picking), 2)


### PR DESCRIPTION
## Qué pasa

El contador que decide cuántos números de remito consume un preimpreso busca el código interno o el barcode del producto en el texto de cada página renderizada y, si no encuentra ninguno, cae a "cualquier página con un número decimal".

Un reporte que repite el encabezado en una hoja final matchea ese fallback con el encabezado mismo — alcanza un "Km 1,4" en un domicilio. La hoja no tiene una sola línea y sin embargo consume un número, y el operador pierde el remito que necesitaba usar después.

## Qué cambia

Cuando el traslado tiene productos con código, manda el código: una página que no trae ninguno tampoco trae líneas. El fallback numérico queda para los traslados cuyos productos no tienen ni código interno ni barcode, donde no hay otra cosa con la que reconocer una línea.

El contador estaba duplicado en el controller de descarga y en el reporte IoT, con el mismo defecto en los dos y sin test sobre la copia del controller — que es por donde pasa toda impresión desde el navegador. Pasa a `stock.picking`, lo comparten los dos callers y queda cubierto.

## Cómo se verifica

- `test_page_without_products_does_not_consume_a_voucher` falla con la lógica vieja: `AssertionError: 2 != 1`.
- Suites de `stock_voucher`, `stock_voucher_ux` y `stock_voucher_ux_iot`: 13 tests, 0 fallos, 0 errores.
- Se elimina el test del módulo IoT que fijaba el comportamiento viejo (daba por buena una página con `"12,50 total"` y sin productos).

Tickets 126294 y 124890.
