### PR TITLE
[IMP] stock_ux: create the lots an inventory count brings

### DIFF
--- a/stock_ux/README.rst
+++ b/stock_ux/README.rst
@@ -40,6 +40,7 @@ Stock UX
 #. Add a "All transfers" view form in Menu: Operations
 #. Add a restriction to edit operation type for users with the "Restrict editing Operation Type in Pickings" check.
 #. Add number of packages on pickings
+#. Create the lots a counted row names and the product does not have yet, instead of stopping the whole file at the first one.
 
 Installation
 ============

--- a/stock_ux/models/stock_quant.py
+++ b/stock_ux/models/stock_quant.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import api, models
 
 
 class StockQuant(models.Model):
@@ -17,4 +17,71 @@ class StockQuant(models.Model):
         quant view."""
         return self.env.context.get("inventory_mode") and self.env.user.has_group(
             "stock_ux.group_stock_inventory_adjustment"
+        )
+
+    # ------------------------------------------------------------------
+    # Spreadsheet import: lots the count brings and Odoo does not have yet
+    # ------------------------------------------------------------------
+
+    @api.model
+    def _convert_records(self, records, *, log=lambda a: None, savepoint):
+        """Create the lots the count names before the importer tries to resolve them:
+        counting a warehouse routinely turns up lots that are new to Odoo, and a single
+        one of them stops the whole file."""
+        if self.env.context.get("import_file"):
+            records = list(records)
+            self._create_missing_import_lots(records)
+        return super()._convert_records(records, log=log, savepoint=savepoint)
+
+    @api.model
+    def _get_import_name(self, value):
+        """Name a row gives for a relational column, which the importer hands over as a
+        sub-record. Anything referenced by id is left alone: it already exists."""
+        if isinstance(value, list) and len(value) == 1 and isinstance(value[0], dict):
+            name = value[0].get(None)
+            return name.strip() if isinstance(name, str) else None
+        return None
+
+    def _create_missing_import_lots(self, records):
+        """Lots named by a row whose product does not have them yet, created for that
+        product so that the row resolves to a lot of its own product."""
+        Product = self.env["product.product"]
+        Location = self.env["stock.location"]
+        resolved = {}
+
+        def resolve(model, name):
+            """Same lookup the importer does on a column given by name."""
+            if (model._name, name) not in resolved:
+                found = model.name_search(name=name, operator="=", limit=1)
+                resolved[model._name, name] = model.browse(found[0][0]) if found else model
+            return resolved[model._name, name]
+
+        wanted = {}
+        for record, _extras in records:
+            lot_name = self._get_import_name(record.get("lot_id"))
+            product_name = self._get_import_name(record.get("product_id"))
+            if not lot_name or not product_name:
+                continue
+            product = resolve(Product, product_name)
+            if not product or product.tracking == "none":
+                continue
+            location_name = self._get_import_name(record.get("location_id"))
+            company = resolve(Location, location_name).company_id if location_name else False
+            wanted[product.id, lot_name] = (company or self.env.company).id
+        if not wanted:
+            return
+        Lot = self.env["stock.lot"]
+        existing = Lot.search(
+            [
+                ("product_id", "in", [product_id for product_id, _name in wanted]),
+                ("name", "in", [name for _product_id, name in wanted]),
+            ]
+        )
+        for lot in existing:
+            wanted.pop((lot.product_id.id, lot.name), None)
+        Lot.create(
+            [
+                {"name": name, "product_id": product_id, "company_id": company_id}
+                for (product_id, name), company_id in wanted.items()
+            ]
         )

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import test_mto_warehouse_propagation
 from . import test_product_uom_qty_location
+from . import test_quant_import_lots

--- a/stock_ux/tests/test_quant_import_lots.py
+++ b/stock_ux/tests/test_quant_import_lots.py
@@ -1,0 +1,60 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("stock_ux_quant_import")
+class TestQuantImportLots(TransactionCase):
+    """Counting a warehouse turns up lots Odoo does not have yet, and the count has to
+    load anyway."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref("stock.group_stock_manager")
+        cls.env.user.group_ids += cls.env.ref("stock_ux.group_stock_inventory_adjustment")
+        cls.location = cls.env.ref("stock.stock_location_stock")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Tracked Product",
+                "is_storable": True,
+                "tracking": "lot",
+            }
+        )
+
+    def _import(self, rows):
+        result = (
+            self.env["stock.quant"]
+            .with_context(import_file=True)
+            .load(["product_id", "location_id", "lot_id", "inventory_quantity"], rows)
+        )
+        self.assertFalse(
+            [message for message in result["messages"] if message["type"] == "error"],
+            result["messages"],
+        )
+        return result
+
+    def _lots(self, name):
+        return self.env["stock.lot"].search(
+            [
+                ("name", "=", name),
+                ("product_id", "=", self.product.id),
+            ]
+        )
+
+    def test_a_lot_the_count_brings_is_created(self):
+        self._import([[self.product.name, self.location.complete_name, "NEW-LOT", "5"]])
+
+        lot = self._lots("NEW-LOT")
+        self.assertEqual(len(lot), 1, "the count names a lot Odoo did not have")
+        quant = self.env["stock.quant"].search([("lot_id", "=", lot.id)])
+        self.assertEqual(quant.inventory_quantity, 5)
+
+    def test_the_same_new_lot_on_two_rows_is_one_lot(self):
+        self._import(
+            [
+                [self.product.name, self.location.complete_name, "NEW-LOT", "5"],
+                [self.product.name, self.location.complete_name, "NEW-LOT", "5"],
+            ]
+        )
+
+        self.assertEqual(len(self._lots("NEW-LOT")), 1)


### PR DESCRIPTION
### What

Counting a warehouse routinely turns up lots that are new to Odoo. Today the importer stops at the first lot name it cannot resolve — `No matching record found for name 'X' in field 'Lot/Serial Number'` — and, since a single error rolls the whole file back, **nothing** is loaded. Creating every new lot by hand before importing the count is the workaround, on files of thousands of rows.

Core already creates the lot when the name resolves to *another* product's lot, so it is only the name that exists nowhere that has no way through. This creates it for the product of the row that names it, right before the importer resolves the column.

### Notes

- Only for products that track lots or serial numbers, only for lots referenced by name (a `lot_id/id` column points at a record that already exists), and in the company of the location the row lands on — the same company core picks when it creates the lot itself.
- Rows naming the same new lot create it once.
- `load()` runs inside a savepoint that is rolled back when the file has errors, so a file that fails for another reason leaves no lots behind. The import preview rolls back the same way.
- Trade-off worth knowing: a typo in a lot name now creates a lot instead of failing the file. That is the same trade-off core already takes on the branch above, and the alternative — the file loading nothing — is what this fixes.

### Test plan

`stock_ux/tests/test_quant_import_lots.py`: a count naming a lot the product does not have loads and lands on the lot that gets created; the same new lot on two rows is one lot.

Ran on 19.0: `0 failed, 0 error(s) of 10 tests`. Without the model file both fail with the message above.

Independent of #1007, #1008 and #1009, which cover the same import from other ends. Merging them together leaves a trivial conflict in the README and in `tests/__init__.py`.

Task: https://www.adhoc.inc/odoo/all-tasks/12857/all-tasks/71351