### PR TITLE
[FIX] stock_ux: negative mirror inherits the push rule of the move it undoes

### DIFF
--- a/stock_ux/models/stock_move.py
+++ b/stock_ux/models/stock_move.py
@@ -4,6 +4,7 @@
 ##############################################################################
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.float_utils import float_compare
 
 
 class StockMove(models.Model):
@@ -98,6 +99,65 @@ class StockMove(models.Model):
         return super(StockMove, self.with_context(cancel_from_order=True, can_delete=True))._merge_moves(
             merge_into=merge_into
         )
+
+    def _get_undone_push_rule(self):
+        """Regla de push del movimiento que este espejo negativo viene a deshacer.
+
+        Devuelve False si no aplica (movimiento positivo, sin destino final, con
+        movimientos destino que el core tiene que re-encadenar, o sin un
+        movimiento vivo del tramo siguiente al que netear).
+        """
+        self.ensure_one()
+        if (
+            float_compare(self.product_uom_qty, 0, precision_rounding=self.product_uom.rounding) >= 0
+            or not self.location_final_id
+            or self.location_dest_id == self.location_final_id
+            or self.move_dest_ids
+        ):
+            return False
+        undone = self.search(
+            [
+                ("id", "!=", self.id),
+                ("group_id", "=", self.group_id.id),
+                ("product_id", "=", self.product_id.id),
+                ("location_id", "=", self.location_dest_id.id),
+                ("location_dest_id", "=", self.location_final_id.id),
+                ("state", "not in", ("draft", "done", "cancel")),
+                ("rule_id.action", "=", "push"),
+                ("product_uom_qty", ">", 0),
+            ],
+            limit=1,
+        )
+        return undone.rule_id
+
+    def _push_apply(self):
+        """El espejo negativo hereda la puerta del movimiento que deshace.
+
+        El core empuja el movimiento positivo en `_action_done` (ya con move
+        lines y con el transportista propagado al picking) y el espejo negativo
+        del cancel-remanente en `_action_confirm` (todavia sin move lines). Si la
+        regla de push discrimina por `push_domain`, las dos evaluaciones pueden
+        resolver reglas distintas: el negativo nace en otro tipo de operacion, no
+        llega a ser candidato del merge, no netea y termina materializado como
+        contra-entrega, dejando el movimiento original huerfano (tarea 73048 /
+        ticket 124472).
+
+        Cuando el tramo siguiente ya existe y esta vivo, la puerta no se vuelve a
+        decidir: se reusa la regla con la que el core creo ese movimiento.
+        """
+        inherited = {}
+        for move in self:
+            rule = move._get_undone_push_rule()
+            if rule:
+                inherited[move.id] = rule
+        if not inherited:
+            return super()._push_apply()
+        new_moves = super(StockMove, self.filtered(lambda m: m.id not in inherited))._push_apply()
+        for move_id, rule in inherited.items():
+            new_move = rule._run_push(self.browse(move_id))
+            if new_move:
+                new_moves |= new_move.sudo()._action_confirm()
+        return new_moves
 
     def action_explode(self):
         # Cuando se explota un kit, MRP cancela y elimina el move original del producto kit,

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_mto_warehouse_propagation
 from . import test_stock_orderpoint_multiple_over_max
 from . import test_return_all_uom
+from . import test_cancel_remaining_push_domain

--- a/stock_ux/tests/test_cancel_remaining_push_domain.py
+++ b/stock_ux/tests/test_cancel_remaining_push_domain.py
@@ -1,0 +1,170 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCancelRemainingPushDomain(TransactionCase):
+    """Entrega multi paso cuya regla de push esta desdoblada en variantes
+    condicionadas por `push_domain` sobre datos de los move lines.
+
+    El core empuja el movimiento positivo en `_action_done` (el move de origen
+    ya tiene move lines) y el espejo negativo del cancel remanente en
+    `_action_confirm` (todavia sin move lines). Con un `push_domain` que lee
+    `move_line_ids`, las dos evaluaciones no resuelven la misma regla: el
+    espejo nace en otro tipo de operacion, no llega a ser candidato del merge,
+    no netea y el movimiento del tramo siguiente queda huerfano y vivo.
+
+    El escenario de control (una sola regla de push, sin dominio) documenta el
+    comportamiento esperado: el espejo netea y el tramo siguiente se cancela.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer_loc = cls.env.ref("stock.stock_location_customers")
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Push Domain", "type": "consu", "is_storable": True}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test Push Domain Customer"})
+
+    def _build_warehouse(self, code, split_push):
+        """Almacen de 2 pasos con ruta pull + push.
+
+        Con `split_push` la regla de push se desdobla en dos variantes que
+        difieren solo en el tipo de operacion, condicionadas por un dato de los
+        move lines del movimiento que se empuja.
+        """
+        warehouse = self.env["stock.warehouse"].create(
+            {"name": "Test Push Domain %s" % code, "code": code, "delivery_steps": "pick_ship"}
+        )
+        route = warehouse.delivery_route_id
+        route.rule_ids.unlink()
+        rule_vals = {
+            "route_id": route.id,
+            "warehouse_id": warehouse.id,
+            "company_id": warehouse.company_id.id,
+        }
+        # Pull: la dispara la demanda de la orden (destino Cliente). El move va
+        # Stock -> Salida (destino del tipo de operacion) con location_final Cliente.
+        self.env["stock.rule"].create(
+            {
+                **rule_vals,
+                "name": "Test Stock -> Customers (pull)",
+                "sequence": 10,
+                "action": "pull",
+                "procure_method": "make_to_stock",
+                "location_src_id": warehouse.lot_stock_id.id,
+                "location_dest_id": self.customer_loc.id,
+                "location_dest_from_rule": False,
+                "picking_type_id": warehouse.pick_type_id.id,
+            }
+        )
+        push_vals = {
+            **rule_vals,
+            "action": "push",
+            "procure_method": "make_to_order",
+            "location_src_id": warehouse.wh_output_stock_loc_id.id,
+            "location_dest_id": self.customer_loc.id,
+        }
+        if split_push:
+            reserved_from = "[('move_line_ids.location_id', '%s', [%s])]"
+            self.env["stock.rule"].create(
+                {
+                    **push_vals,
+                    "name": "Test Output -> Customers (push, reserved)",
+                    "sequence": 20,
+                    "picking_type_id": warehouse.out_type_id.id,
+                    "push_domain": reserved_from % ("in", warehouse.lot_stock_id.id),
+                }
+            )
+            self.env["stock.rule"].create(
+                {
+                    **push_vals,
+                    "name": "Test Output -> Customers (push, not reserved)",
+                    "sequence": 30,
+                    "picking_type_id": warehouse.out_type_id.copy(
+                        {
+                            "name": "Delivery Orders Alt",
+                            "sequence_code": "OUTALT",
+                            "warehouse_id": warehouse.id,
+                        }
+                    ).id,
+                    "push_domain": reserved_from % ("not in", warehouse.lot_stock_id.id),
+                }
+            )
+        else:
+            self.env["stock.rule"].create(
+                {
+                    **push_vals,
+                    "name": "Test Output -> Customers (push)",
+                    "sequence": 20,
+                    "picking_type_id": warehouse.out_type_id.id,
+                }
+            )
+        self.env["stock.quant"]._update_available_quantity(self.product, warehouse.lot_stock_id, 100)
+        return warehouse
+
+    def _moves_report(self, order, label):
+        moves = self.env["stock.move"].search(
+            [("product_id", "=", self.product.id), ("company_id", "=", order.company_id.id)], order="id"
+        )
+        report = ["--- %s ---" % label]
+        for move in moves:
+            report.append(
+                "  move %s picking=%s type=%s %s -> %s final=%s qty=%s state=%s to_refund=%s"
+                % (
+                    move.id,
+                    move.picking_id.name or "-",
+                    move.picking_type_id.name or "-",
+                    move.location_id.name,
+                    move.location_dest_id.name,
+                    move.location_final_id.name or "-",
+                    move.product_uom_qty,
+                    move.state,
+                    move.to_refund,
+                )
+            )
+        return "\n".join(report)
+
+    def _cancel_remaining_after_first_step(self, code, split_push):
+        warehouse = self._build_warehouse(code, split_push)
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": warehouse.id,
+                "order_line": [(0, 0, {"product_id": self.product.id, "product_uom_qty": 10})],
+            }
+        )
+        order.action_confirm()
+        report = [self._moves_report(order, "%s: orden confirmada" % code)]
+
+        picking = order.picking_ids.filtered(lambda p: p.picking_type_id == warehouse.pick_type_id)
+        self.assertTrue(picking, "no se creo el primer paso\n" + "\n".join(report))
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+            move.picked = True
+        picking.button_validate()
+        report.append(self._moves_report(order, "%s: primer paso validado" % code))
+
+        next_step = order.order_line.move_ids.filtered(
+            lambda m: m.location_dest_id == self.customer_loc and m.state not in ("done", "cancel")
+        )
+        self.assertTrue(next_step, "no se empujo el tramo siguiente\n" + "\n".join(report))
+
+        order.order_line.with_context(cancel_from_order=True).button_cancel_remaining()
+        report.append(self._moves_report(order, "%s: remanente cancelado" % code))
+        return next_step, "\n".join(report)
+
+    def test_cancel_remaining_cancels_next_step(self):
+        """Control: con una sola regla de push el espejo netea el tramo siguiente."""
+        next_step, report = self._cancel_remaining_after_first_step("TPDA", split_push=False)
+        self.assertEqual(next_step.state, "cancel", "el tramo siguiente deberia quedar cancelado\n" + report)
+
+    def test_cancel_remaining_cancels_next_step_with_push_domain(self):
+        """El espejo hereda la puerta del tramo que deshace y netea igual."""
+        next_step, report = self._cancel_remaining_after_first_step("TPDB", split_push=True)
+        self.assertEqual(next_step.state, "cancel", "el tramo siguiente deberia quedar cancelado\n" + report)


### PR DESCRIPTION
## Problema

Al cancelar el remanente de una línea, el core baja la demanda y lanza un aprovisionamiento negativo. El espejo de ese negativo se empuja en `_action_confirm`, **antes de tener move lines**, mientras que el movimiento positivo que viene a deshacer se empujó en `_action_done`, cuando el movimiento de origen ya tenía líneas (y el transportista ya estaba propagado al picking).

Si la regla de push tiene un `push_domain` que lee `move_line_ids`, las dos evaluaciones no resuelven la misma regla:

- el espejo nace en **otro tipo de operación**;
- `_search_picking_for_assignation` no le encuentra picking (y los negativos no crean uno);
- nunca llega a ser candidato del merge → no netea;
- se invierte y queda materializado como **contra-entrega**.

El movimiento del tramo siguiente queda **vivo y huérfano**. El daño se consuma cuando se valida: las cantidades de la orden dejan de cerrar y la devolución se duplica.

Es el mismo mecanismo de la familia de "cancelar remanente / contra-entrega", con un disparador distinto: acá el negativo no falla la llave del merge — **no llega a ser candidato**.

## Solución

Cuando el tramo siguiente **ya existe y está vivo**, la puerta no se vuelve a decidir: se reusa la regla con la que el core creó ese movimiento.

- No toca `button_cancel_remaining`, no cancela cadenas, no toca cantidades, no reimplementa ruteo.
- **En una ruta con una sola regla de push el fix es un no-op**: la regla que hereda es la misma que el core iba a elegir. Solo se despega cuando las dos evaluaciones divergen, que es exactamente el bug.
- Cubre venta y compra (vive en `stock.move`, no en el módulo de venta).
- Guards: solo movimientos negativos, con `location_final_id` distinto del destino, **sin `move_dest_ids`** (si los tiene, el core tiene que re-encadenarlos y se delega entero a `super()`), y solo si hay un movimiento vivo del tramo siguiente creado por una regla de push.

## Test plan

`stock_ux/tests/test_cancel_remaining_push_domain.py` — almacén de 2 pasos con ruta pull + push, validar el primer paso y cancelar el remanente:

| escenario | esperado |
|---|---|
| una sola regla de push (control) | el tramo siguiente queda `cancel` |
| regla desdoblada en variantes con `push_domain` | el tramo siguiente queda `cancel` |

Verificado en local (Odoo 18):

- **sin el fix**: el caso `push_domain` falla (`'assigned' != 'cancel'` — la salida queda viva con la cantidad original + un movimiento espejo de más); el control pasa.
- **con el fix**: los dos pasan.
- `/stock`, `/sale_stock`, `/stock_delivery`: lista de fallos **idéntica** con y sin el fix (41 fallos preexistentes de la base de prueba, ninguno nuevo).

## Fuera de alcance

No resuelve la familia entera: cuando el tramo siguiente **todavía no existe** (rutas pull+push+push donde el cancel llega antes de que nazca la salida) no hay puerta que heredar y el problema sigue. Eso va por otro lado.

Ref: https://www.adhoc.inc/odoo/project.task/73048
