### PR TITLE
[FIX] stock_ux: keep the scrap source location in sync with its move

### DIFF
--- a/stock_ux/__manifest__.py
+++ b/stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock UX",
-    "version": "18.0.1.12.0",
+    "version": "18.0.1.13.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_ux/models/__init__.py
+++ b/stock_ux/models/__init__.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from . import stock_move
+from . import stock_scrap
 from . import stock_picking
 from . import stock_return_picking
 from . import product_template

--- a/stock_ux/models/stock_scrap.py
+++ b/stock_ux/models/stock_scrap.py
@@ -1,0 +1,18 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class StockScrap(models.Model):
+    _inherit = "stock.scrap"
+
+    @api.depends("company_id", "picking_id", "move_ids.move_line_ids.location_id")
+    def _compute_location_id(self):
+        """La ubicación de origen sigue al movimiento, que es el único lugar donde se la
+        puede corregir una vez hecho el desecho."""
+        from_move = self.filtered(lambda x: x.move_ids.move_line_ids.location_id)
+        super(StockScrap, self - from_move)._compute_location_id()
+        for scrap in from_move:
+            scrap.location_id = scrap.move_ids.move_line_ids.location_id[0]

--- a/stock_ux/tests/__init__.py
+++ b/stock_ux/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_mto_warehouse_propagation
 from . import test_stock_orderpoint_multiple_over_max
 from . import test_return_all_uom
+from . import test_scrap_location_follows_move

--- a/stock_ux/tests/test_scrap_location_follows_move.py
+++ b/stock_ux/tests/test_scrap_location_follows_move.py
@@ -1,0 +1,38 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestScrapLocationFollowsMove(TransactionCase):
+    """La ubicación de origen del desecho sigue a la de su movimiento, que es donde se
+    la puede corregir una vez hecho."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.location = cls.warehouse.lot_stock_id
+        cls.other_location = cls.env["stock.location"].create(
+            {
+                "name": "Otro Stock",
+                "usage": "internal",
+                "location_id": cls.warehouse.view_location_id.id,
+                "company_id": cls.env.company.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create({"name": "Producto a desechar", "is_storable": True})
+
+    def test_location_follows_corrected_move_line(self):
+        self.env["stock.quant"]._update_available_quantity(self.product, self.location, 5)
+        scrap = self.env["stock.scrap"].create(
+            {
+                "product_id": self.product.id,
+                "product_uom_id": self.product.uom_id.id,
+                "scrap_qty": 1,
+                "location_id": self.location.id,
+            }
+        )
+        scrap.do_scrap()
+        self.assertEqual(scrap.location_id, self.location)
+
+        scrap.move_ids.move_line_ids.location_id = self.other_location
+        self.assertEqual(scrap.location_id, self.other_location)


### PR DESCRIPTION
The scrap's source location is copied into the move when the scrap is validated
(`_prepare_move_values`, from `do_scrap`) and the field is readonly from then on.
Correcting the location on the move line -the only place where it can be corrected
once the scrap is done, and it does fix the quants- left the scrap order still
showing the original location, both in the form and in the list view.

`location_id` only depends on `company_id` and `picking_id`, so nothing brings the
correction back to the header. Same behaviour in 16.0, 18.0 and 19.0.

## What this does

Override `_compute_location_id` in `stock_ux` adding `move_ids.move_line_ids.location_id`
to the dependencies: when the scrap already has a move, the location comes from its
move lines; when it has none, core keeps deciding exactly as before.

Two implementation notes:

- The core dependencies (`company_id`, `picking_id`) are repeated on purpose: the new
  decorator replaces the inherited one, and dropping them would break the propagation
  from the picking while the scrap is still a draft.
- `super()` runs only on the scraps without a move, so a done scrap is never reset to
  the default warehouse location.

## Test plan

`stock_ux/tests/test_scrap_location_follows_move.py`: validate a scrap, correct the
location on its move line, assert the order follows.

```
stock_ux: 16 tests 3.84s 2735 queries
0 failed, 0 error(s)
```

The test discriminates - with the model import disabled it fails:

```
FAIL: TestScrapLocationFollowsMove.test_location_follows_corrected_move_line
AssertionError: stock.location(8,) != stock.location(48,)
```

Reported in https://www.adhoc.inc/odoo/helpdesk.ticket/126534
