### PR TITLE
[FIX] stock_voucher: exclude backordered moves from the declared value

### DIFF
--- a/stock_voucher/__manifest__.py
+++ b/stock_voucher/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Voucher",
-    "version": "18.0.1.7.1",
+    "version": "18.0.1.8.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "summary": "",

--- a/stock_voucher/models/stock_picking.py
+++ b/stock_voucher/models/stock_picking.py
@@ -193,7 +193,20 @@ class StockPicking(models.Model):
             inmediate_transfer = True
             pricelist = False
             stock_bom_lines = self.env["stock.move"]
-            for move_line in rec.move_ids.filtered(lambda x: x.state != "cancel"):
+            moves = rec.move_ids.filtered(lambda x: x.state != "cancel")
+            # While _action_done runs, the picking still holds the moves that are about
+            # to be split off into the backorder: stock.move._create_backorder already
+            # created and confirmed them (so they are reserved when there is stock) and
+            # stock.picking._create_backorder has not moved them out yet. Right in
+            # between, _create_backorder_picking copies the picking and copy_data reads
+            # this field, forcing the pending recomputation. Counting those moves would
+            # declare what was shipped plus what the backorder reserved, and the state
+            # filter above would then freeze that value. Once a move is done, only the
+            # done ones are what this voucher actually ships.
+            done_moves = moves.filtered(lambda x: x.state == "done")
+            if done_moves:
+                moves = done_moves
+            for move_line in moves:
                 order_line = move_line.sale_line_id
                 if move_line.quantity:
                     inmediate_transfer = False

--- a/stock_voucher/tests/__init__.py
+++ b/stock_voucher/tests/__init__.py
@@ -5,3 +5,4 @@
 from . import test_stock_picking_voucher
 from . import test_stock_book
 from . import test_stock_picking
+from . import test_declared_value

--- a/stock_voucher/tests/test_declared_value.py
+++ b/stock_voucher/tests/test_declared_value.py
@@ -1,0 +1,144 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestDeclaredValue(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.warehouse.out_type_id.automatic_declare_value = True
+        partner_vals = {"name": "Declared Value Customer"}
+        if "partner_state" in cls.env["res.partner"]._fields:
+            # sale_exception_partner_state manda a excepción los pedidos de un
+            # contacto sin aprobar, y sin confirmar no hay entrega que medir
+            partner_vals["partner_state"] = "approved"
+        cls.partner = cls.env["res.partner"].create(partner_vals)
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "Declared Value Pricelist",
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        cls.product_a = cls._create_product("DV-A", 100.0)
+        cls.product_b = cls._create_product("DV-B", 250.0)
+
+    @classmethod
+    def _create_product(cls, code, price):
+        return cls.env["product.product"].create(
+            {
+                "name": code,
+                "default_code": code,
+                "type": "consu",
+                "is_storable": True,
+                "list_price": price,
+            }
+        )
+
+    def _set_stock(self, product, qty):
+        self.env["stock.quant"]._update_available_quantity(product, self.warehouse.lot_stock_id, qty)
+
+    def _create_order(self, lines):
+        """Confirma y vacía el entorno: en la UI confirmar el pedido es su propio request."""
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist.id,
+                "order_line": [(0, 0, {"product_id": product.id, "product_uom_qty": qty}) for product, qty in lines],
+            }
+        )
+        order.action_confirm()
+        self.env.flush_all()
+        return order
+
+    def _line_price(self, order, product):
+        return order.order_line.filtered(lambda x: x.product_id == product).price_reduce_taxexcl
+
+    def test_partial_delivery_with_stock_for_backorder(self):
+        """El movimiento del backorder queda reservado al validar y no se declara."""
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.quantity = 30
+        picking.move_ids.picked = True
+
+        picking.with_context(skip_backorder=True).button_validate()
+
+        price = self._line_price(order, self.product_a)
+        backorder = order.picking_ids - picking
+        self.assertAlmostEqual(picking.declared_value, price * 30, places=2)
+        self.assertAlmostEqual(backorder.declared_value, price * 70, places=2)
+
+    def test_partial_delivery_without_stock_for_backorder(self):
+        self._set_stock(self.product_a, 30)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.picked = True
+
+        picking.with_context(skip_backorder=True).button_validate()
+
+        price = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price * 30, places=2)
+
+    def test_full_delivery(self):
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.picked = True
+
+        picking.with_context(skip_backorder=True).button_validate()
+
+        price = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price * 100, places=2)
+
+    def test_move_entirely_backordered(self):
+        """Un movimiento que no salió se muda entero al backorder y no se declara."""
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100), (self.product_b, 10)])
+        picking = order.picking_ids
+        picking.action_assign()
+
+        picking.with_context(skip_backorder=True).button_validate()
+
+        price_a = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price_a * 100, places=2)
+
+    def test_kit_partial_delivery(self):
+        """En kits el prorrateo promedia por componente: sólo deben entrar los hechos."""
+        if "mrp.bom" not in self.env:
+            self.skipTest("mrp no instalado")
+        component_a = self._create_product("DV-C1", 10.0)
+        component_b = self._create_product("DV-C2", 20.0)
+        kit = self._create_product("DV-KIT", 1000.0)
+        self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": kit.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "phantom",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": component_a.id, "product_qty": 2.0}),
+                    (0, 0, {"product_id": component_b.id, "product_qty": 3.0}),
+                ],
+            }
+        )
+        self._set_stock(component_a, 1000)
+        self._set_stock(component_b, 1000)
+        order = self._create_order([(kit, 10)])
+        picking = order.picking_ids
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.quantity = 12 if move.product_id == component_a else 18
+        picking.move_ids.picked = True
+
+        picking.with_context(skip_backorder=True).button_validate()
+
+        price = self._line_price(order, kit)
+        self.assertAlmostEqual(picking.declared_value, price * 6, places=2)


### PR DESCRIPTION
## Qué pasa hoy

En una entrega parcial, el valor declarado del remito sale igual al **saldo pendiente de la línea de venta**, no a lo que efectivamente se carga en el camión. Sobre una orden de 2.550 unidades entregada en cuatro parciales, cada remito declaró el saldo previo al parcial y no lo despachado. El peso y la cantidad de bultos salen bien, porque esos sí se recalculan al validar.

Falla **sólo cuando hay stock para el remanente**, de ahí que sea intermitente.

## Causa

`_compute_declared_value` corre una última vez adentro de `_action_done`, disparada por `copy_data` cuando `_create_backorder_picking()` copia el picking. En ese instante el remito todavía cuelga los movimientos que se van al backorder: `stock.move._create_backorder` ya los partió y confirmó —y con stock disponible quedan reservados— y `stock.picking._create_backorder` aún no los mudó. El compute suma su cantidad reservada a `done_value`, o sea declara **lo entregado más lo reservado del backorder**. Dos líneas después el picking pasa a `done` y el filtro de estado del compute vuelve permanente ese valor.

En kits el efecto es peor: el prorrateo promedia por componente e incluye también los del backorder, así que el valor sale mal tanto si el remanente es reservable (promedia entregado y pendiente) como si no (promedia contra cero).

## El cambio

Cuando el remito ya tiene movimientos en `done`, el cálculo toma sólo esos. Esa condición sólo se da dentro de `_action_done`, y ahí los movimientos incompletos son exactamente los que se van al backorder.

## Test plan

`stock_voucher/tests/test_declared_value.py`, cinco casos con datos creados en el test:

| Caso | Antes | Después |
| --- | --- | --- |
| Parcial 30 de 100, con stock para el backorder | 10.000 | 3.000 |
| Parcial 30 de 100, sin stock para el backorder | 3.000 | 3.000 |
| Entrega completa | 10.000 | 10.000 |
| Movimiento que se muda entero al backorder | 10.000 | 10.000 |
| Kit, parcial 6 de 10 con stock para el resto | 5.000 | 6.000 |
| Kit, parcial 6 de 10 sin stock para el resto | 3.000 | 6.000 |

Los seis escenarios se corrieron uno por uno sobre una base restaurada, con el compute original y con el parcheado, comparando el valor en base antes y después de validar.

La suite se corrió además sobre una base local con `demo_full` (438 módulos, todo el stack OBA): **5 tests, 0 errores**. Sin el fix, en esa misma base fallan los dos que reproducen el problema —`test_partial_delivery_with_stock_for_backorder` (10.000 ≠ 3.000) y `test_kit_partial_delivery` (5.000 ≠ 6.000)— y pasan los tres de control.

El `setUpClass` marca el contacto como aprobado cuando `partner_state` existe: con el stack completo, `sale_exception_partner_state` manda a excepción el pedido de un contacto sin aprobar y sin confirmar no hay entrega que medir. El test de kits se saltea si `mrp` no está instalado.

## Antecedentes

Los PRs #793 y #854 tocaron esta misma función por reportes emparentados, pero los dos corrigieron el prorrateo de kits, no el conjunto de movimientos sobre el que se prorratea, así que el caso general de entrega parcial seguía abierto.

## Limitación conocida, fuera de alcance

Si confirmar y validar caen en la misma transacción y no hay backorder de por medio, ningún recálculo llega antes de que el picking pase a `done` y `declared_value` queda en `NULL`. Se verificó que ya ocurre sin este cambio. No afecta a la UI, donde cada acción es su propio request.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127364
