### PR TITLE
[FIX] stock_declared_value: declared value on partial deliveries

### DIFF
--- a/stock_declared_value/__manifest__.py
+++ b/stock_declared_value/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Declared Value",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Warehouse Management",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/stock_declared_value/models/stock_picking.py
+++ b/stock_declared_value/models/stock_picking.py
@@ -28,7 +28,20 @@ class StockPicking(models.Model):
             inmediate_transfer = True
             pricelist = False
             stock_bom_lines = self.env["stock.move"]
-            for move_line in rec.move_ids.filtered(lambda x: x.state != "cancel"):
+            moves = rec.move_ids.filtered(lambda x: x.state != "cancel")
+            # While _action_done runs, the picking still holds the moves that are about
+            # to be split off into the backorder: stock.move._create_backorder already
+            # created and confirmed them (so they are reserved when there is stock) and
+            # stock.picking._create_backorder has not moved them out yet. Right in
+            # between, _create_backorder_picking copies the picking and copy_data reads
+            # this field, forcing the pending recomputation. Counting those moves would
+            # declare what was shipped plus what the backorder reserved, and the state
+            # filter above would then freeze that value. Once a move is done, only the
+            # done ones are what this voucher actually ships.
+            done_moves = moves.filtered(lambda x: x.state == "done")
+            if done_moves:
+                moves = done_moves
+            for move_line in moves:
                 order_line = move_line.sale_line_id
                 if move_line.quantity:
                     inmediate_transfer = False
@@ -70,9 +83,8 @@ class StockPicking(models.Model):
                         bom_moves = so_bom_line.move_ids & stock_bom_lines._origin
                         done_avg = []
                         picking_avg = []
-                        boms, lines = bom.sudo().explode(
-                            so_bom_line.product_id, so_bom_line.product_uom_qty, picking_type=bom.picking_type_id
-                        )
+                        # Explode for 1 kit to get base quantities per component
+                        boms, lines = bom.sudo().explode(so_bom_line.product_id, 1.0, picking_type=bom.picking_type_id)
                         for move in bom_moves:
                             bom_quantity = 0.0
                             for bom_line, line_data in lines:
@@ -80,10 +92,15 @@ class StockPicking(models.Model):
                                     bom_quantity += line_data["qty"]
                             if not bom_quantity:
                                 continue
+                            rec_move = rec.move_ids.filtered(lambda m: m._origin.id == move.id)
+                            if not rec_move:
+                                continue
                             picking_avg.append(move.product_uom_qty / bom_quantity)
-                            done_avg.append(move.quantity / bom_quantity)
-                        picking_value += so_bom_line.price_reduce_taxexcl * (sum(picking_avg) / len(picking_avg))
-                        done_value += so_bom_line.price_reduce_taxexcl * (sum(done_avg) / len(done_avg))
+                            done_avg.append(rec_move.quantity / bom_quantity)
+                        if picking_avg and done_avg:
+                            # Average represents how many kits, multiply by unit price
+                            picking_value += so_bom_line.price_reduce_taxexcl * (sum(picking_avg) / len(picking_avg))
+                            done_value += so_bom_line.price_reduce_taxexcl * (sum(done_avg) / len(done_avg))
 
             declared_value = picking_value if inmediate_transfer else done_value
             if pricelist:

--- a/stock_declared_value/tests/__init__.py
+++ b/stock_declared_value/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_declared_value

--- a/stock_declared_value/tests/test_declared_value.py
+++ b/stock_declared_value/tests/test_declared_value.py
@@ -1,0 +1,150 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestDeclaredValue(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.warehouse.out_type_id.automatic_declare_value = True
+        partner_vals = {"name": "Declared Value Customer"}
+        if "partner_state" in cls.env["res.partner"]._fields:
+            # sale_exception_partner_state manda a excepción los pedidos de un
+            # contacto sin aprobar, y sin confirmar no hay entrega que medir
+            partner_vals["partner_state"] = "approved"
+        cls.partner = cls.env["res.partner"].create(partner_vals)
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "Declared Value Pricelist",
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        cls.product_a = cls._create_product("DV-A", 100.0)
+        cls.product_b = cls._create_product("DV-B", 250.0)
+
+    @classmethod
+    def _create_product(cls, code, price):
+        return cls.env["product.product"].create(
+            {
+                "name": code,
+                "default_code": code,
+                "type": "consu",
+                "is_storable": True,
+                "list_price": price,
+            }
+        )
+
+    def _set_stock(self, product, qty):
+        self.env["stock.quant"]._update_available_quantity(product, self.warehouse.lot_stock_id, qty)
+
+    def _create_order(self, lines):
+        """Confirma y vacía el entorno: en la UI confirmar el pedido es su propio request."""
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist.id,
+                "order_line": [(0, 0, {"product_id": product.id, "product_uom_qty": qty}) for product, qty in lines],
+            }
+        )
+        order.action_confirm()
+        self.env.flush_all()
+        return order
+
+    def _validate(self, picking):
+        """En 19 el asistente de stock_sms intercepta la validación y devuelve una
+        acción en vez de validar; skip_sms la saltea, skip_backorder crea el backorder
+        sin abrir el wizard."""
+        return picking.with_context(skip_backorder=True, skip_sms=True).button_validate()
+
+    def _line_price(self, order, product):
+        return order.order_line.filtered(lambda x: x.product_id == product).price_reduce_taxexcl
+
+    def test_partial_delivery_with_stock_for_backorder(self):
+        """El movimiento del backorder queda reservado al validar y no se declara."""
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.quantity = 30
+        picking.move_ids.picked = True
+
+        self._validate(picking)
+
+        price = self._line_price(order, self.product_a)
+        backorder = order.picking_ids - picking
+        self.assertAlmostEqual(picking.declared_value, price * 30, places=2)
+        self.assertAlmostEqual(backorder.declared_value, price * 70, places=2)
+
+    def test_partial_delivery_without_stock_for_backorder(self):
+        self._set_stock(self.product_a, 30)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.picked = True
+
+        self._validate(picking)
+
+        price = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price * 30, places=2)
+
+    def test_full_delivery(self):
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100)])
+        picking = order.picking_ids
+        picking.action_assign()
+        picking.move_ids.picked = True
+
+        self._validate(picking)
+
+        price = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price * 100, places=2)
+
+    def test_move_entirely_backordered(self):
+        """Un movimiento que no salió se muda entero al backorder y no se declara."""
+        self._set_stock(self.product_a, 1000)
+        order = self._create_order([(self.product_a, 100), (self.product_b, 10)])
+        picking = order.picking_ids
+        picking.action_assign()
+
+        self._validate(picking)
+
+        price_a = self._line_price(order, self.product_a)
+        self.assertAlmostEqual(picking.declared_value, price_a * 100, places=2)
+
+    def test_kit_partial_delivery(self):
+        """En kits el prorrateo promedia por componente: sólo deben entrar los hechos."""
+        if "mrp.bom" not in self.env:
+            self.skipTest("mrp no instalado")
+        component_a = self._create_product("DV-C1", 10.0)
+        component_b = self._create_product("DV-C2", 20.0)
+        kit = self._create_product("DV-KIT", 1000.0)
+        self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": kit.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "phantom",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": component_a.id, "product_qty": 2.0}),
+                    (0, 0, {"product_id": component_b.id, "product_qty": 3.0}),
+                ],
+            }
+        )
+        self._set_stock(component_a, 1000)
+        self._set_stock(component_b, 1000)
+        order = self._create_order([(kit, 10)])
+        picking = order.picking_ids
+        picking.action_assign()
+        for move in picking.move_ids:
+            move.quantity = 12 if move.product_id == component_a else 18
+        picking.move_ids.picked = True
+
+        self._validate(picking)
+
+        price = self._line_price(order, kit)
+        self.assertAlmostEqual(picking.declared_value, price * 6, places=2)


### PR DESCRIPTION
## Qué pasa hoy

En una entrega parcial, el valor declarado del remito sale igual al **saldo pendiente de la línea de venta**, no a lo que efectivamente se carga en el camión. Sobre una orden entregada en varios parciales, cada remito declara el saldo previo al parcial y no lo despachado. El peso y la cantidad de bultos salen bien, porque esos sí se recalculan al validar.

Falla **sólo cuando hay stock para el remanente**, de ahí que sea intermitente.

## Causa

`_compute_declared_value` corre una última vez adentro de `_action_done`, disparada por `copy_data` cuando `_create_backorder_picking()` copia el picking. En ese instante el remito todavía cuelga los movimientos que se van al backorder: `stock.move._create_backorder` ya los partió y confirmó —y con stock disponible quedan reservados— y `stock.picking._create_backorder` aún no los mudó. El compute suma su cantidad reservada a `done_value`, o sea declara **lo entregado más lo reservado del backorder**. Dos líneas después el picking pasa a `done` y el filtro de estado del compute vuelve permanente ese valor.

La secuencia es de core y no cambió respecto de 18.0. Este módulo desciende de `stock_delivery_advance` y trae su propia copia del compute, que nunca recibió los arreglos que sí se le hicieron en 18.0 (`stock_voucher`).

## El cambio

Cuando el remito ya tiene movimientos en `done`, el cálculo toma sólo esos. Esa condición sólo se da dentro de `_action_done`, y ahí los movimientos incompletos son exactamente los que se van al backorder.

Como se reparó todo el compute, se portaron además los arreglos que faltaban respecto de 18.0, todos en la rama de kits:

- `explode()` de la BoM para **1 unidad** en vez de la cantidad pedida — sin esto el valor declarado de kits salía multiplicado/dividido por la cantidad del pedido.
- La cantidad despachada se lee del movimiento del propio remito (`rec_move`), no del movimiento de origen.
- Se saltea el componente que no tiene movimiento en el remito.
- Guarda contra división por cero en el promedio de kits (antes, excepción en la cara del usuario).

## Test plan

`stock_declared_value/tests/test_declared_value.py`, cinco casos con datos creados en el test:

| Caso | Sin el fix | Con el fix |
| --- | --- | --- |
| Parcial 30 de 100, con stock para el backorder | 10.000 | 3.000 |
| Parcial 30 de 100, sin stock para el backorder | 3.000 | 3.000 |
| Entrega completa | 10.000 | 10.000 |
| Movimiento que se muda entero al backorder | 10.000 | 10.000 |
| Kit, parcial 6 de 10 con stock para el resto | 500 → 600 | 6.000 |

La suite se corrió sobre una base local (sin demo, `stock_declared_value` + `sale_mrp`): **5 tests, 0 errores**. Con el compute revertido al original fallan los dos que reproducen el problema —`test_partial_delivery_with_stock_for_backorder` (10.000 ≠ 3.000) y `test_kit_partial_delivery` (≠ 6.000)— y pasan los tres de control.

El `setUpClass` marca el contacto como aprobado cuando `partner_state` existe: con el stack completo, `sale_exception_partner_state` manda a excepción el pedido de un contacto sin aprobar y sin confirmar no hay entrega que medir. La validación usa `skip_backorder` y `skip_sms` (en 19 el asistente de `stock_sms` intercepta la validación). El test de kits se saltea si `mrp` no está instalado.

## Antecedentes

Es el port a 19.0 del arreglo hecho en 18.0 sobre `stock_voucher` (PR ingadhoc/stock#1030), sobre el módulo que en 19.0 quedó como sucesor del compute.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127364
